### PR TITLE
Implement index adjustment for rel json ptr

### DIFF
--- a/jschon/jsonpointer.py
+++ b/jschon/jsonpointer.py
@@ -281,7 +281,7 @@ class RelativeJSONPointer:
         :param over: the integer value used to adjust the array index after
             applying `up`, which is only valid if that location is an array item;
             a value of 0, which is not allowed by the grammar, is treated as if
-            there is no adjutsment.
+            there is no adjustment.
         :param ref: either the literal ``#``, or a :class:`JSONPointer` instance,
             or a JSON pointer-conformant string
         :raise RelativeJSONPointerError: for any invalid arguments
@@ -294,7 +294,7 @@ class RelativeJSONPointer:
 
             up, over, ref = match.group('up', 'over', 'ref')
 
-        if over in (0, ''):
+        if not over:
             self.over = 0
             self._over_str = ''
         else:
@@ -347,7 +347,7 @@ class RelativeJSONPointer:
             if node.parent.type != "array":
                 raise RelativeJSONPointerError(f'Index adjustment not valid for type {node.parent.type}')
             adjusted = int(node.key) + self.over
-            if adjusted < 0 or adjusted > len(node.parent):
+            if adjusted < 0 or adjusted >= len(node.parent):
                 raise RelativeJSONPointerError(f'Index adjustment out of range')
             node = node.parent[adjusted]
 

--- a/tests/data/relative_jsonpointer.json
+++ b/tests/data/relative_jsonpointer.json
@@ -247,12 +247,17 @@
             },
             {
                 "start": "/2/baz",
-                "ref": "1+5",
+                "ref": "1+1",
                 "result": "<fail>"
             },
             {
                 "start": "/2/baz",
                 "ref": "0+1",
+                "result": "<fail>"
+            },
+            {
+                "start": "/1",
+                "ref": "0-2",
                 "result": "<fail>"
             }
         ]

--- a/tests/data/relative_jsonpointer.json
+++ b/tests/data/relative_jsonpointer.json
@@ -259,6 +259,11 @@
                 "start": "/1",
                 "ref": "0-2",
                 "result": "<fail>"
+            },
+            {
+                "start": "/0",
+                "ref": "1+1/2/baz",
+                "result": "<fail>"
             }
         ]
     }

--- a/tests/data/relative_jsonpointer.json
+++ b/tests/data/relative_jsonpointer.json
@@ -217,5 +217,44 @@
                 "result": "awkwardly/named~variable"
             }
         ]
+    },
+    {
+        "data": [
+            "foo",
+            "bar",
+            {"baz": "value"}
+        ],
+        "tests": [
+            {
+                "start": "/0",
+                "ref": "0+1",
+                "result": "bar"
+            },
+            {
+                "start": "/1",
+                "ref": "0-1#",
+                "result": 0
+            },
+            {
+                "start": "/0",
+                "ref": "0+2/baz",
+                "result": "value"
+            },
+            {
+                "start": "/2/baz",
+                "ref": "1-2",
+                "result": "foo"
+            },
+            {
+                "start": "/2/baz",
+                "ref": "1+5",
+                "result": "<fail>"
+            },
+            {
+                "start": "/2/baz",
+                "ref": "0+1",
+                "result": "<fail>"
+            }
+        ]
     }
 ]

--- a/tests/data/relative_jsonpointer.json
+++ b/tests/data/relative_jsonpointer.json
@@ -264,6 +264,11 @@
                 "start": "/0",
                 "ref": "1+1/2/baz",
                 "result": "<fail>"
+            },
+            {
+                "start": "/0",
+                "ref": "0/anything",
+                "result": "<fail>"
             }
         ]
     }

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -41,9 +41,14 @@ jsonproperties = hs.dictionaries(propname, jsonleaf, max_size=10)
 
 jsonpointer_regex = '(/([^~/]|(~[01]))*)*'
 jsonpointer_index = '0|([1-9][0-9]*)'
+jsonpointer_index_manip = r'((\+|-)[1-9][0-9]*)?'
 jsonpointer = hs.from_regex(jsonpointer_regex, fullmatch=True)
 jsonpointer_key = hs.text() | hs.sampled_from(['~', '/', '-']) | hs.from_regex(jsonpointer_index, fullmatch=True)
-relative_jsonpointer_regex = f'(?P<up>{jsonpointer_index})(?P<ref>#|{jsonpointer_regex})'
+relative_jsonpointer_regex = (
+    f'(?P<up>{jsonpointer_index})'
+    f'(?P<over>{jsonpointer_index_manip})'
+    f'(?P<ref>#|{jsonpointer_regex})'
+)
 relative_jsonpointer = hs.from_regex(relative_jsonpointer_regex, fullmatch=True)
 
 interdependent_keywords = hs.lists(hs.sampled_from([

--- a/tests/test_jsonpointer.py
+++ b/tests/test_jsonpointer.py
@@ -123,11 +123,19 @@ def test_compare_jsonpointer(value1, value2):
 @given(relative_jsonpointer)
 def test_create_relative_jsonpointer(value):
     match = re.fullmatch(relative_jsonpointer_regex, value)
-    up, ref = match.group('up', 'ref')
+    up, over, ref = match.group('up', 'over', 'ref')
+    kwargs = {
+        'up': up,
+        'ref': ref,
+    }
+    if over:
+        kwargs['over'] = over
+
     r1 = RelativeJSONPointer(value)
-    r2 = RelativeJSONPointer(up=up, ref=ref)
+    r2 = RelativeJSONPointer(**kwargs)
     assert r1 == r2
     assert str(r1) == value
+    assert eval(repr(r1)) == r1
 
     if up == 0:
         assert r1 == RelativeJSONPointer(ref=ref)
@@ -136,12 +144,14 @@ def test_create_relative_jsonpointer(value):
         if ref != '#':
             assert r1 == RelativeJSONPointer(ref=JSONPointer(ref))
     if ref == '':
-        assert r1 == RelativeJSONPointer(up=up)
+        del kwargs['ref']
+        assert r1 == RelativeJSONPointer(**kwargs)
 
 
 # Examples from:
 # https://datatracker.ietf.org/doc/html/draft-handrews-relative-json-pointer-01#section-5.1
 # https://gist.github.com/geraintluff/5911303
+# https://gist.github.com/handrews/62d9ae0abe8938c910f7f4906cfa53f9
 example_file = pathlib.Path(__file__).parent / 'data' / 'relative_jsonpointer.json'
 
 

--- a/tests/test_jsonpointer.py
+++ b/tests/test_jsonpointer.py
@@ -126,10 +126,9 @@ def test_create_relative_jsonpointer(value):
     up, over, ref = match.group('up', 'over', 'ref')
     kwargs = {
         'up': up,
+        'over': over,
         'ref': ref,
     }
-    if over:
-        kwargs['over'] = over
 
     r1 = RelativeJSONPointer(value)
     r2 = RelativeJSONPointer(**kwargs)

--- a/tests/test_jsonpointer.py
+++ b/tests/test_jsonpointer.py
@@ -136,14 +136,18 @@ def test_create_relative_jsonpointer(value):
     assert str(r1) == value
     assert eval(repr(r1)) == r1
 
-    if up == 0:
-        assert r1 == RelativeJSONPointer(ref=ref)
-        if ref == '':
-            assert r1 == RelativeJSONPointer()
-        if ref != '#':
-            assert r1 == RelativeJSONPointer(ref=JSONPointer(ref))
+    if ref != '#':
+        kwargs['ref'] = JSONPointer(ref)
+        assert r1 == RelativeJSONPointer(**kwargs)
+
+    oldkwargs = kwargs
+    if up == '0':
+        del kwargs['up']
+    if over == '':
+        del kwargs['over']
     if ref == '':
         del kwargs['ref']
+    if kwargs != oldkwargs:
         assert r1 == RelativeJSONPointer(**kwargs)
 
 


### PR DESCRIPTION
Fixes #23 : Adds support for index adjustment to class `RelativeJSONPointer` per the [most recent draft](https://datatracker.ietf.org/doc/html/draft-bhutton-relative-json-pointer-00), as modified by [recently proposed fixes](https://github.com/handrews/json-schema-spec/compare/main...handrews:json-schema-spec:relptr-more-fixes) that correct errors in the original wording for index adjustment.

@marksparkza I've tried to match styles, but I'm perfectly happy to change formatting or wording or whatever so feel free to nitpick.  I've not used type hinting in Python before so if I missed something obvious that I should have done with types it's because I don't know what I'm doing :-)

For the tests, I matched the sort of tests that were already present.  I noticed some things that were not covered, such as some syntax error conditions, but I have filed those ideas as issue #48.

I started writing a tutorial page for `RelativeJSONPointer`, but decided to submit it as a separate PR.

With the adjustment to hypothesis 6.0.3 per #45 , all tests run and pass on Python 3.8, 3.9, 3.10, and 3.11.

**jsonpointer.py coverage HTML page header _before_:**
```
Coverage for jschon/jsonpointer.py: 93%
143 statements    134 run    9 missing    11 excluded    4 partial
```

**jsonpointer.py coverage HTML page header _after_:**
```
Coverage for jschon/jsonpointer.py: 96%
143 statements    137 run    6 missing    11 excluded    3 partial
```

**Test & coverage report _before_**:
```
------------------------------------------------------------------------------------------------- benchmark: 5 tests -------------------------------------------------------------------------------------------------
Name (time in us)                      Min                    Max                  Mean                StdDev                Median                 IQR            Outliers          OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_create_json                   40.0420 (1.0)      22,765.2910 (49.10)       55.9223 (1.0)        241.7498 (6.51)        41.2089 (1.0)        2.4159 (1.0)        2;2022  17,881.9634 (1.0)        8983           1
test_evaluate_json[valid]         151.0840 (3.77)     15,631.1250 (33.72)      172.3141 (3.08)       256.0344 (6.89)       157.4580 (3.82)       4.5430 (1.88)        1;583   5,803.3546 (0.32)       3702           1
test_evaluate_json[invalid]       180.6669 (4.51)        463.6250 (1.0)        199.4462 (3.57)        37.1391 (1.0)        186.0000 (4.51)       4.7920 (1.98)      558;601   5,013.8835 (0.28)       3268           1
test_create_schema                481.7080 (12.03)    25,930.1249 (55.93)      546.1360 (9.77)       898.4470 (24.19)      496.2500 (12.04)     22.5734 (9.34)         3;43   1,831.0458 (0.10)       1463           1
test_validate_schema            2,487.3330 (62.12)    43,008.5000 (92.77)    3,375.4863 (60.36)    4,836.1567 (130.22)   2,542.6251 (61.70)    635.9163 (263.22)        6;6     296.2536 (0.02)        367           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
========================================================================= 2396 passed in 113.10s (0:01:53) ==========================================================================
py310: commands_post[0]> coverage report
Name                              Stmts   Miss Branch BrPart  Cover
-------------------------------------------------------------------
jschon/__init__.py                   20      2      2      0    91%
jschon/catalog/_2019_09.py           18      0      0      0   100%
jschon/catalog/_2020_12.py           18      0      0      0   100%
jschon/catalog/__init__.py          136     11     30      3    89%
jschon/catalog/_next.py              18      0      0      0   100%
jschon/exceptions.py                 14      0      0      0   100%
jschon/formats.py                     7      0      4      1    91%
jschon/json.py                      210     11     86      4    95%
jschon/jsonpatch.py                 169     43     60     15    70%
jschon/jsonpointer.py               128      6     40      2    95%
jschon/jsonschema.py                263     18    121     11    90%
jschon/output.py                     80      2     41      1    96%
jschon/uri.py                        68      2     14      2    95%
jschon/utils.py                      40      5     12      2    87%
jschon/vocabulary/__init__.py        69      6     24      5    86%
jschon/vocabulary/annotation.py      36      0      2      0   100%
jschon/vocabulary/applicator.py     254      0    147      2    99%
jschon/vocabulary/core.py           123     14     36      8    85%
jschon/vocabulary/format.py          28      0      4      0   100%
jschon/vocabulary/legacy.py         100      2     58      5    96%
jschon/vocabulary/validation.py     159      0     68      1    99%
-------------------------------------------------------------------
TOTAL                              1958    122    749     62    92%
```

**Test & coverage report _after_:**
```
------------------------------------------------------------------------------------------------- benchmark: 5 tests -------------------------------------------------------------------------------------------------
Name (time in us)                      Min                    Max                  Mean                StdDev                Median                 IQR            Outliers          OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_create_json                   40.5411 (1.0)         735.0410 (1.52)        55.1769 (1.0)         36.5315 (1.10)        42.3340 (1.0)        4.1666 (1.0)        61;494  18,123.5242 (1.0)        2164           1
test_evaluate_json[valid]         153.1660 (3.78)        482.3339 (1.0)        170.9793 (3.10)        33.1258 (1.0)        159.5829 (3.77)       4.5832 (1.10)      631;686   5,848.6608 (0.32)       4201           1
test_evaluate_json[invalid]       181.4590 (4.48)     15,583.5000 (32.31)      203.9511 (3.70)       244.8774 (7.39)       187.1660 (4.42)       5.1241 (1.23)       18;743   4,903.1356 (0.27)       4034           1
test_create_schema                482.4999 (11.90)    26,491.4590 (54.92)      545.4101 (9.88)       852.8854 (25.75)      498.5830 (11.78)     23.8648 (5.73)         3;72   1,833.4826 (0.10)       1667           1
test_validate_schema            2,493.6250 (61.51)    46,667.7080 (96.75)    3,446.7382 (62.47)    5,215.5207 (157.45)   2,557.6040 (60.41)    638.9170 (153.34)        6;6     290.1294 (0.02)        360           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
========================================================================= 2402 passed in 123.74s (0:02:03) ==========================================================================
py310: commands_post[0]> coverage report
Name                              Stmts   Miss Branch BrPart  Cover
-------------------------------------------------------------------
jschon/__init__.py                   20      2      2      0    91%
jschon/catalog/_2019_09.py           18      0      0      0   100%
jschon/catalog/_2020_12.py           18      0      0      0   100%
jschon/catalog/__init__.py          136     11     30      3    89%
jschon/catalog/_next.py              18      0      0      0   100%
jschon/exceptions.py                 14      0      0      0   100%
jschon/formats.py                     7      0      4      1    91%
jschon/json.py                      210     11     86      4    95%
jschon/jsonpatch.py                 169     43     60     15    70%
jschon/jsonpointer.py               143      6     50      3    95%
jschon/jsonschema.py                263     18    121     11    90%
jschon/output.py                     80      2     41      1    96%
jschon/uri.py                        68      2     14      2    95%
jschon/utils.py                      40      5     12      2    87%
jschon/vocabulary/__init__.py        69      6     24      5    86%
jschon/vocabulary/annotation.py      36      0      2      0   100%
jschon/vocabulary/applicator.py     254      0    147      2    99%
jschon/vocabulary/core.py           123     14     36      8    85%
jschon/vocabulary/format.py          28      0      4      0   100%
jschon/vocabulary/legacy.py         100      2     58      5    96%
jschon/vocabulary/validation.py     159      0     68      1    99%
-------------------------------------------------------------------
TOTAL                              1973    122    759     63    92%
```