### PR TITLE
Restrict hypothesis<6.0.4 due to a bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'dev': [
             'pytest',
             'coverage',
-            'hypothesis',
+            'hypothesis<6.0.4',
             'pytest-benchmark',
             'pytest-httpserver',
             'requests',

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py38, py39, py310
 deps =
     pytest
     coverage
-    hypothesis
+    hypothesis<6.0.4
     pytest-benchmark
     pytest-httpserver
     requests


### PR DESCRIPTION
Temporarily fixes #45.

The race condition fix for recursive() in hypothesis 6.0.4 has broken the tests on Python 3.10 (and 3.11) due to the presence of pytest-httpserver.  At least on an Apple M1 Pro chip.

Restrict it to 6.0.3 until the problem and solution are understood. Note that all versions of pytest-httpserver seem to have the problem.

See the following issues on GitHub to track:

* csernazs/pytest-httpserver#217
* HypothesisWorks/hypothesis#3585