### PR TITLE
Collect unknown keywords as annotations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Features:
 * Annotation filtering for `basic` output format (#32)
 * JSON ``null``, ``true``, ``false`` literals
 * Relative JSON Pointer ``+``/``-`` array index adjustments
+* Unknown keywords are collected as annotations
 
 Experimental:
 

--- a/jschon/jsonschema.py
+++ b/jschon/jsonschema.py
@@ -110,7 +110,7 @@ class JSONSchema(JSON):
             kwclasses = {
                 key: kwclass for key in value
                 if (key not in self.keywords and  # skip bootstrapped keywords
-                    (kwclass := self.metaschema.kwclasses.get(key)))
+                    (kwclass := self.metaschema.get_kwclass(key)))
             }
 
             for kwclass in self._resolve_dependencies(kwclasses):

--- a/jschon/vocabulary/__init__.py
+++ b/jschon/vocabulary/__init__.py
@@ -51,18 +51,21 @@ class Metaschema(JSONSchema):
             for vocabulary in self.default_vocabularies:
                 self.kwclasses.update(vocabulary.kwclasses)
 
-    def get_kwclass(self, key):
+    def get_kwclass(self, key: str) -> Type[Keyword]:
+        """Return the :class:`Keyword` class this metaschema uses for the given key.
+        If the key is not recognized, a subclass of :class:`AnnotationKeyword` is
+        automatically created, associated with the key, and returned."""
+
         try:
             return self.kwclasses[key]
         except KeyError:
             capitalized_name = (
-                key[0].upper() +
-                (key[1:] if len(key) > 1 else "")
+                key[0].upper() + key[1:]
             )
             unknown_class = type(
                 f'UnknownKeyword{capitalized_name}',
                 (AnnotationKeyword,),
-                {'key': key},
+                dict(key=key),
             )
             self.kwclasses[key] = unknown_class
             return unknown_class
@@ -121,14 +124,9 @@ class Keyword:
 KeywordClass = Type[Keyword]
 
 
-class AnnotationMixin(Keyword):
+class AnnotationKeyword(Keyword):
     def evaluate(self, instance: JSON, result: Result) -> None:
         result.annotate(self.json.data)
-
-
-class AnnotationKeyword(AnnotationMixin):
-    def evaluate(self, instance: JSON, result: Result) -> None:
-        super().evaluate(instance, result)
         result.noassert()
 
 

--- a/jschon/vocabulary/annotation.py
+++ b/jschon/vocabulary/annotation.py
@@ -3,6 +3,7 @@ from jschon.jsonschema import Result
 from jschon.vocabulary import AnnotationKeyword
 
 __all__ = [
+    'AnnotationKeyword',
     'TitleKeyword',
     'DescriptionKeyword',
     'DefaultKeyword',

--- a/jschon/vocabulary/annotation.py
+++ b/jschon/vocabulary/annotation.py
@@ -1,6 +1,6 @@
 from jschon.json import JSON
 from jschon.jsonschema import Result
-from jschon.vocabulary import Keyword
+from jschon.vocabulary import AnnotationKeyword
 
 __all__ = [
     'TitleKeyword',
@@ -14,13 +14,6 @@ __all__ = [
     'ContentEncodingKeyword',
     'ContentSchemaKeyword',
 ]
-
-
-class AnnotationKeyword(Keyword):
-
-    def evaluate(self, instance: JSON, result: Result) -> None:
-        result.annotate(self.json.data)
-        result.noassert()
 
 
 class TitleKeyword(AnnotationKeyword):

--- a/jschon/vocabulary/annotation.py
+++ b/jschon/vocabulary/annotation.py
@@ -1,9 +1,8 @@
 from jschon.json import JSON
 from jschon.jsonschema import Result
-from jschon.vocabulary import AnnotationKeyword
+from jschon.vocabulary import Keyword
 
 __all__ = [
-    'AnnotationKeyword',
     'TitleKeyword',
     'DescriptionKeyword',
     'DefaultKeyword',
@@ -15,6 +14,13 @@ __all__ = [
     'ContentEncodingKeyword',
     'ContentSchemaKeyword',
 ]
+
+
+class AnnotationKeyword(Keyword):
+
+    def evaluate(self, instance: JSON, result: Result) -> None:
+        result.annotate(self.json.data)
+        result.noassert()
 
 
 class TitleKeyword(AnnotationKeyword):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -436,3 +436,21 @@ def test_hierarchical_output(input, valid, catalog):
     output_schema = catalog.get_schema(URI('https://json-schema.org/draft/next/output/schema'))
     output_validity = output_schema.evaluate(JSON(output))
     assert output_validity.valid is True
+
+@pytest.mark.parametrize('draft', ['2019-09', '2020-12', 'next'])
+def test_unknown_keywords_as_annotations(draft):
+    schema = JSONSchema({
+        "$schema": f"https://json-schema.org/draft/{draft}/schema",
+        "$id": "https://example.com/schema",
+        "extra": "annotation",
+    })
+    output = schema.evaluate(JSON({})).output('basic')
+    assert output == {
+        'valid': True,
+        'annotations': [{
+            'instanceLocation': '',
+            'keywordLocation': '/extra',
+            'absoluteKeywordLocation': 'https://example.com/schema#/extra',
+            'annotation': 'annotation',
+        }],
+    }


### PR DESCRIPTION
Fixes #24.  This supports collecting unknown keywords as annotation by encapsulating keyword class retrieval into a method, which dynamically creates classes prefixed with `UnknownKeyword` that inherit from `AnnotationKeyword`, and caches the results with the other keyword classes.

To avoid circular dependencies, this  moves the `AnnotationKeyword` class from the `jschon.vocabulary.annotation` module into the `jschon.vocabulary` module with the `Applicator` and `ApplicatorMixin` classes, and splits it similarly into `AnnotationKeyword` and `AnnotationMixin`.

`AnnotationKeyword` is specifically a keyword that is _only_ an annotation, while `AnnotationMixin` stores the annotation but does not preclude further action by subclasses.

Since `AnnotationKeyword` is still imported into `jschon.vocabulary.annotation`, any code relying on being able to import it from there should still work.  There do not appear to be any such imports within jschon or its tests.

There are other ways this could be tested, but the included test covers the changed code, and I'm planning to add more tests around vocabularies and meta-schemas after analyzing the coverage reports in more detail.

------
```
------------------------------------------------------------------------------------------------- benchmark: 5 tests -------------------------------------------------------------------------------------------------
Name (time in us)                      Min                    Max                  Mean                StdDev                Median                 IQR            Outliers          OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_create_json                   40.2911 (1.0)      19,984.2080 (43.29)       56.1091 (1.0)        226.0353 (6.09)        41.5000 (1.0)        2.4170 (1.0)        2;1775  17,822.4145 (1.0)        7921           1
test_evaluate_json[valid]         153.8752 (3.82)     14,723.1249 (31.90)      173.5659 (3.09)       215.8083 (5.81)       159.3751 (3.84)       4.3022 (1.78)       23;732   5,761.5018 (0.32)       4649           1
test_evaluate_json[invalid]       181.5001 (4.50)        461.5840 (1.0)        201.3841 (3.59)        37.1386 (1.0)        188.1660 (4.53)       4.1146 (1.70)      717;750   4,965.6353 (0.28)       4191           1
test_create_schema                481.2079 (11.94)    24,520.5411 (53.12)      545.7938 (9.73)       872.3568 (23.49)      495.7090 (11.94)     23.0831 (9.55)         3;41   1,832.1938 (0.10)       1426           1
test_validate_schema            2,489.9999 (61.80)    41,206.1249 (89.27)    3,315.5801 (59.09)    4,535.8887 (122.13)   2,540.2079 (61.21)    634.0828 (262.34)        5;5     301.6063 (0.02)        327           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
========================== 2399 passed in 106.70s (0:01:46) ==========================
py310: commands_post[0]> coverage report
Name                              Stmts   Miss Branch BrPart  Cover
-------------------------------------------------------------------
jschon/__init__.py                   20      2      2      0    91%
jschon/catalog/_2019_09.py           18      0      0      0   100%
jschon/catalog/_2020_12.py           18      0      0      0   100%
jschon/catalog/__init__.py          136     11     30      3    89%
jschon/catalog/_next.py              18      0      0      0   100%
jschon/exceptions.py                 14      0      0      0   100%
jschon/formats.py                     7      0      4      1    91%
jschon/json.py                      210     11     86      4    95%
jschon/jsonpatch.py                 169     43     60     15    70%
jschon/jsonpointer.py               128      6     40      2    95%
jschon/jsonschema.py                263     18    121     11    90%
jschon/output.py                     80      2     41      1    96%
jschon/uri.py                        68      2     14      2    95%
jschon/utils.py                      40      5     12      2    87%
jschon/vocabulary/__init__.py        84      6     24      5    88%
jschon/vocabulary/annotation.py      32      0      2      0   100%
jschon/vocabulary/applicator.py     254      0    147      2    99%
jschon/vocabulary/core.py           123     14     36      8    85%
jschon/vocabulary/format.py          28      0      4      0   100%
jschon/vocabulary/legacy.py         100      2     58      5    96%
jschon/vocabulary/validation.py     159      0     68      1    99%
-------------------------------------------------------------------
TOTAL                              1969    122    749     62    92%
py310: commands_post[1]> coverage html
Wrote HTML report to htmlcov/index.html
.pkg: _exit> python /Users/handrews/dev/.venv/lib/python3.8/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  py38: OK (117.18=setup[1.05]+cmd[115.55,0.21,0.37] seconds)
  py39: OK (110.26=setup[1.58]+cmd[108.14,0.20,0.33] seconds)
  py310: OK (108.97=setup[1.05]+cmd[107.37,0.20,0.36] seconds)
  congratulations :) (336.51 seconds)
```