### PR TITLE
Update hierarchical output: nested -> details

### DIFF
--- a/jschon/output.py
+++ b/jschon/output.py
@@ -136,11 +136,11 @@ def hierarchical(result: Result) -> JSONCompatible:
                 "schemaLocation": str(node.absolute_uri),
                 "instanceLocation": str(node.instance.path),
             }
-            nested = []
+            details = []
             annotations = {}
             errors = {}
             for child in node.children.values():
-                nested += [
+                details += [
                     childout for childout in (visit(child))
                     if child.valid == valid
                 ]
@@ -149,8 +149,8 @@ def hierarchical(result: Result) -> JSONCompatible:
                 elif not valid and child.error is not None:
                     errors[child.key] = child.error
 
-            if nested:
-                output["nested"] = nested
+            if details:
+                output["details"] = details
             if valid and annotations:
                 output["annotations"] = annotations
             elif not valid and errors:


### PR DESCRIPTION
I'm going to claim that this fixes #52, where I got rather confused about hierarchical output support.  Not mentioned there but relevant and in need of addressing:

The "nested" key was changed to "details" with issue json-schema-org/json-schema-spec#1347 and PR json-schema-org/json-schema-spec#1351

@marksparkza should I add "hierarchical" to the list of available outputs in the docstrings or are you intentionally leaving it out because it is experimental?  Since it (and the proposed "list" format) are backwards-compatible, I'd propose documenting it.