### PR TITLE
Run individual JSON Schema test suite files

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,11 @@ def pytest_addoption(parser):
         action="store_true",
         help="Include format tests",
     )
+    testsuite.addoption(
+        "--testsuite-file",
+        action="append",
+        help="Run only this file from the JSON Schema test suite. The option may be repeated to run multiple files. Using this option causes --testsuite-optionals and --testsuite-formats to be ignored"
+    )
 
 
 @pytest.fixture(scope='module', autouse=True)


### PR DESCRIPTION
The --testsuite-file option allows selecting individual files from the suite, which is helpful when you are testing one new or changed keyword.

I set this up for myself while working on some draft-next keywords and figured I'd submit it.  No problem if you'd rather not add this as I can just use it locally :-)