### PR TITLE
Resolve embedded schema URIs in new remote schemas

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Breaking changes:
 Bug Fixes:
 
 * "$dynamicRef" works with non-plain-name fragment URIs
+* Fixed remote anchor ref resolution
 
 Documentation:
 

--- a/jschon/catalog/__init__.py
+++ b/jschon/catalog/__init__.py
@@ -278,6 +278,10 @@ class Catalog:
                 uri=base_uri,
                 metaschema_uri=metaschema_uri,
             )
+            try:
+                return self._schema_cache[cacheid][uri]
+            except KeyError:
+                pass
 
         if uri.fragment:
             try:


### PR DESCRIPTION
I originally thought this was a much bigger problem (see confused ramblings in issue #58), but it turned out to be a tiny fix.

Updating the JSON-Schema-Test-Suite submodule resulted in new test failures, which exposed that when calling Catalog.get_schema() on a URI with a plain name or no fragment requries loading a schema for the first time, the cache was not being re-checked for the original URI afterwards.

The remaining logic worked fine for the remote's retrieval URI or for a JSON Pointer that used that URI as a base. However, if the URI differed from the retrieval URI or included a plain name fragment, the schema would not be found despite being in the catalog.