### PR TITLE
Auto-create metaschemas referenced in "$schema"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,9 @@ Features:
 * JSON ``null``, ``true``, ``false`` literals
 * Relative JSON Pointer ``+``/``-`` array index adjustments
 * Unknown keywords are collected as annotations
+* Automatically create metaschemas as referenced by ``"$schema"``
+* Automatically detect the core vocabulary in metaschemas,
+  but allow specifying a default to use when none is detectable
 
 Experimental:
 
@@ -23,6 +26,10 @@ Breaking changes:
 * ``Catalog.add_format_validators()`` superseded by ``@format_validator`` / ``Catalog.enable_formats()``
 * Rename ``Catalog.session()`` context manager to ``Catalog.cache()``
 * Rename ``session`` parameter to ``cacheid`` in many places
+* Added ``Catalog.get_metaschema()``, analogous to ``Catalog.get_schema()``
+* Rename ``core_vocabulary`` and ``core_vocabulary_uri`` parameters for
+  ``Metaschema.__init__()`` and ``Catalog.create_metaschema()`` respectively to
+  ``default_core_vocabulary`` and ``default_core_vocabulary_uri``
 * Rename public functions in the ``jsonpatch`` module
 
 Documentation:

--- a/jschon/jsonschema.py
+++ b/jschon/jsonschema.py
@@ -218,7 +218,7 @@ class JSONSchema(JSON):
                 return parent
             parent = parent.parent
 
-    @property
+    @cached_property
     def metaschema(self) -> Metaschema:
         """The schema's :class:`~jschon.vocabulary.Metaschema`."""
         from jschon.vocabulary import Metaschema
@@ -226,13 +226,7 @@ class JSONSchema(JSON):
         if (uri := self.metaschema_uri) is None:
             raise JSONSchemaError("The schema's metaschema URI has not been set")
 
-        if not isinstance(
-                metaschema := self.catalog.get_schema(uri, cacheid='__meta__'),
-                Metaschema,
-        ):
-            raise JSONSchemaError(f"The schema referenced by {uri} is not a metachema")
-
-        return metaschema
+        return self.catalog.get_metaschema(uri)
 
     @property
     def metaschema_uri(self) -> Optional[URI]:

--- a/jschon/vocabulary/__init__.py
+++ b/jschon/vocabulary/__init__.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import re
 import inspect
 from typing import Any, Dict, Mapping, Optional, Sequence, TYPE_CHECKING, Tuple, Type
 
 from jschon.json import JSON, JSONCompatible
 from jschon.jsonschema import JSONSchema, Result
+from jschon.exceptions import JSONSchemaError
 from jschon.uri import URI
 
 if TYPE_CHECKING:
@@ -30,17 +32,54 @@ class Metaschema(JSONSchema):
     :class:`Metaschema` is itself a subclass of :class:`~jschon.jsonschema.JSONSchema`,
     and may be used to validate any referencing schema.
     """
+    _CORE_VOCAB_RE = r'https://json-schema\.org/draft/[^/]*/vocab/core$'
 
     def __init__(
             self,
             catalog: Catalog,
             value: Mapping[str, JSONCompatible],
-            core_vocabulary: Vocabulary,
+            default_core_vocabulary: Optional[Vocabulary] = None,
             *default_vocabularies: Vocabulary,
             **kwargs: Any,
     ):
-        self.core_vocabulary: Vocabulary = core_vocabulary
+        """Initialize a :class:`Metaschema` instance from the given
+        schema-compatible `value`.
+
+        :param catalog: catalog instance or catalog name
+        :param value: a schema-compatible Python object
+        :param default_core_vocabulary: the the metaschema's
+            core :class:`~jschon.vocabulary.Vocabulary`, used in the absence
+            of a ``"$vocabulary"`` keyword in the metaschema JSON file, or
+            if a known core vocabulary is not present under ``"$vocabulary"``
+        :param default_vocabulary: default :class:`~jschon.vocabulary.Vocabulary`
+            instances, used in the absence of a ``"$vocabulary"`` keyword in the
+            metaschema JSON file
+        :param kwargs: additional keyword arguments to pass through to the
+            :class:`~jschon.jsonschema.JSONSchema` constructor
+
+        :raise JSONSchemaError: if no core vocabulary can be determined
+        :raise CatalogError: if the created metaschema is not valid
+        """
         self.default_vocabularies: Tuple[Vocabulary, ...] = default_vocabularies
+        self.core_vocabulary: Vocabulary = default_core_vocabulary
+
+        if vocabularies := value.get("$vocabulary"):
+            possible_cores = list(filter(
+                lambda v: re.match(self._CORE_VOCAB_RE, v),
+                vocabularies,
+            ))
+            if len(possible_cores) == 1:
+                self.core_vocabulary = catalog.get_vocabulary(URI(possible_cores[0]))
+            else:
+                raise JSONSchemaError(
+                    'Cannot determine unique known core vocabulary from '
+                    f'candidates "{vocabularies.keys()}"'
+                )
+        if self.core_vocabulary is None:
+            raise JSONSchemaError(
+                'No core vocabulary in "$vocabulary", and no default provided'
+            )
+
         self.kwclasses: Dict[str, KeywordClass] = {}
         super().__init__(value, catalog=catalog, cacheid='__meta__', **kwargs)
 


### PR DESCRIPTION
Fixes #68 , although I'm submitting it as a draft to indicate that I'm not particularly confident that this is the ideal way to solve it.  But it's a starting point, at least.

Test coverage will be provided by PR #70, which includes cases that fail without this change.

This change allows the tests added in
PR json-schema-org/JSON-Schema-Test-Suite#646 to pass, in accordance with §9.3.1 of the spec, "Detecting a Meta-Schema".

* Catalog.get_metaschema() is added, and is analogous in behavior to Catalog.get_schema(), relying on Catalog.create_metaschema()
* It is called from the now-cached JSONSchema.metaschema property, to keep the parallel with references which are only resolved when used
* Catalog.create_metaschema() now returns the created metaschema to avoid having to immediately look it up again
* The core_vocabulary parameters have become default_core_vocabulary parameters to allow not knowing the core in advance
* The Metaschema constructor now looks in "$vocabulary" for a vocabulary URI matching r'^https://json-schema\.org/draft/[^/]*/core' and if it finds a unique match, uses that instead of the default
* Lack of a recognizable core vocabulary still results in a JSONSchemaError exception if no default is provided