### PR TITLE
Automatically create metaschemas when accessing JSONSchema.metaschema

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "JSON-Schema-Test-Suite"]
 	path = tests/JSON-Schema-Test-Suite
 	url = https://github.com/json-schema-org/JSON-Schema-Test-Suite
-	branch = master
+	branch = main
 [submodule "json-schema-spec-2019-09"]
 	path = jschon/catalog/json-schema-spec-2019-09
 	url = https://github.com/json-schema-org/json-schema-spec

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Features:
 * Relative JSON Pointer ``+``/``-`` array index adjustments
 * Unknown keywords are collected as annotations
 * Automatically create metaschemas as referenced by ``"$schema"``
+  on first access of the now-cached ``JSONSchema.metaschema`` property
 * Automatically detect the core vocabulary in metaschemas,
   but allow specifying a default to use when none is detectable
 
@@ -26,11 +27,6 @@ Breaking changes:
 * ``Catalog.add_format_validators()`` superseded by ``@format_validator`` / ``Catalog.enable_formats()``
 * Rename ``Catalog.session()`` context manager to ``Catalog.cache()``
 * Rename ``session`` parameter to ``cacheid`` in many places
-* Added ``Catalog.get_metaschema()``, analogous to ``Catalog.get_schema()``
-* ``Catalog.create_metashema()`` and ``Catalog.create_vocabulary()`` return the created instance
-* Rename ``core_vocabulary`` and ``core_vocabulary_uri`` parameters for
-  ``Metaschema.__init__()`` and ``Catalog.create_metaschema()`` respectively to
-  ``default_core_vocabulary`` and ``default_core_vocabulary_uri``
 * Rename public functions in the ``jsonpatch`` module
 * Rename ``*Applicator*`` keyword class mixins to ``*Subschema*``
 
@@ -51,6 +47,11 @@ Miscellaneous:
 * Add ``JSONCompatible`` and ``Result`` classes to the top-level package API
 * Remove implicit fall-through to looking up a schema in the `__meta__` cache
   if not found in the parameterized cache, in ``Catalog.get_schema()`` (#40)
+* Added ``Catalog.get_metaschema()``, analogous to ``Catalog.get_schema()``
+* ``Catalog.create_metashema()`` and ``Catalog.create_vocabulary()`` return the created instance
+* Rename ``core_vocabulary`` and ``core_vocabulary_uri`` parameters for
+  ``Metaschema.__init__()`` and ``Catalog.create_metaschema()`` respectively to
+  ``default_core_vocabulary`` and ``default_core_vocabulary_uri``
 * Improve kwarg-based construction of ``RelativeJSONPointer``
 * Allow passthrough of arguments to pytest when invoking tox
 * Add pytest command line options ``--testsuite-file`` and ``--testsuite-description``

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,9 @@ Features:
 * JSON ``null``, ``true``, ``false`` literals
 * Relative JSON Pointer ``+``/``-`` array index adjustments
 * Unknown keywords are collected as annotations
+* Automatically create metaschemas as referenced by ``"$schema"``
+* Automatically detect the core vocabulary in metaschemas,
+  but allow specifying a default to use when none is detectable
 
 Experimental:
 
@@ -23,6 +26,11 @@ Breaking changes:
 * ``Catalog.add_format_validators()`` superseded by ``@format_validator`` / ``Catalog.enable_formats()``
 * Rename ``Catalog.session()`` context manager to ``Catalog.cache()``
 * Rename ``session`` parameter to ``cacheid`` in many places
+* Added ``Catalog.get_metaschema()``, analogous to ``Catalog.get_schema()``
+* ``Catalog.create_metashema()`` and ``Catalog.create_vocabulary()`` return the created instance
+* Rename ``core_vocabulary`` and ``core_vocabulary_uri`` parameters for
+  ``Metaschema.__init__()`` and ``Catalog.create_metaschema()`` respectively to
+  ``default_core_vocabulary`` and ``default_core_vocabulary_uri``
 * Rename public functions in the ``jsonpatch`` module
 * Rename ``*Applicator*`` keyword class mixins to ``*Subschema*``
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,7 +48,7 @@ Miscellaneous:
 * Remove implicit fall-through to looking up a schema in the `__meta__` cache
   if not found in the parameterized cache, in ``Catalog.get_schema()`` (#40)
 * Added ``Catalog.get_metaschema()``, analogous to ``Catalog.get_schema()``
-* ``Catalog.create_metashema()`` and ``Catalog.create_vocabulary()`` return the created instance
+* ``Catalog.create_metaschema()`` and ``Catalog.create_vocabulary()`` return the created instance
 * Rename ``core_vocabulary`` and ``core_vocabulary_uri`` parameters for
   ``Metaschema.__init__()`` and ``Catalog.create_metaschema()`` respectively to
   ``default_core_vocabulary`` and ``default_core_vocabulary_uri``

--- a/examples/custom_keyword.py
+++ b/examples/custom_keyword.py
@@ -62,20 +62,6 @@ catalog.create_vocabulary(
     EnumRefKeyword,
 )
 
-# compile the enumRef metaschema, which enables any referencing schema
-# to use the keyword implementations provided by its vocabularies
-catalog.create_metaschema(
-    URI("https://example.com/enumRef/enumRef-metaschema"),
-    URI("https://json-schema.org/draft/2020-12/vocab/core"),
-    URI("https://json-schema.org/draft/2020-12/vocab/applicator"),
-    URI("https://json-schema.org/draft/2020-12/vocab/unevaluated"),
-    URI("https://json-schema.org/draft/2020-12/vocab/validation"),
-    URI("https://json-schema.org/draft/2020-12/vocab/format-annotation"),
-    URI("https://json-schema.org/draft/2020-12/vocab/meta-data"),
-    URI("https://json-schema.org/draft/2020-12/vocab/content"),
-    URI("https://example.com/enumRef"),
-)
-
 # create a schema for validating that a string is a member of a remote enumeration
 schema = JSONSchema({
     "$schema": "https://example.com/enumRef/enumRef-metaschema",

--- a/jschon/catalog/_2019_09.py
+++ b/jschon/catalog/_2019_09.py
@@ -96,13 +96,3 @@ def initialize(catalog: Catalog):
         ContentEncodingKeyword,
         ContentSchemaKeyword,
     )
-
-    catalog.create_metaschema(
-        URI("https://json-schema.org/draft/2019-09/schema"),
-        URI("https://json-schema.org/draft/2019-09/vocab/core"),
-        URI("https://json-schema.org/draft/2019-09/vocab/applicator"),
-        URI("https://json-schema.org/draft/2019-09/vocab/validation"),
-        URI("https://json-schema.org/draft/2019-09/vocab/format"),
-        URI("https://json-schema.org/draft/2019-09/vocab/meta-data"),
-        URI("https://json-schema.org/draft/2019-09/vocab/content"),
-    )

--- a/jschon/catalog/_2020_12.py
+++ b/jschon/catalog/_2020_12.py
@@ -99,14 +99,3 @@ def initialize(catalog: Catalog):
         ContentEncodingKeyword,
         ContentSchemaKeyword,
     )
-
-    catalog.create_metaschema(
-        URI("https://json-schema.org/draft/2020-12/schema"),
-        URI("https://json-schema.org/draft/2020-12/vocab/core"),
-        URI("https://json-schema.org/draft/2020-12/vocab/applicator"),
-        URI("https://json-schema.org/draft/2020-12/vocab/unevaluated"),
-        URI("https://json-schema.org/draft/2020-12/vocab/validation"),
-        URI("https://json-schema.org/draft/2020-12/vocab/format-annotation"),
-        URI("https://json-schema.org/draft/2020-12/vocab/meta-data"),
-        URI("https://json-schema.org/draft/2020-12/vocab/content"),
-    )

--- a/jschon/catalog/__init__.py
+++ b/jschon/catalog/__init__.py
@@ -150,7 +150,7 @@ class Catalog:
         :param kwclasses: the :class:`~jschon.vocabulary.Keyword` classes
             constituting the vocabulary
 
-        :returns: the newly created :class:`Vocabulary` instance
+        :returns: the newly created :class:`~jschon.vocabulary.Vocabulary` instance
         """
         self._vocabularies[uri] = Vocabulary(uri, *kwclasses)
         return self._vocabularies[uri]
@@ -186,7 +186,7 @@ class Catalog:
         :param kwargs: additional keyword arguments to pass through to the
             :class:`~jschon.jsonschema.JSONSchema` constructor
 
-        :returns: the newly created :class:`Metaschema` instance
+        :returns: the newly created :class:`~jschon.vocabulary.Metaschema` instance
 
         :raise CatalogError: if the metaschema is not valid
         """
@@ -220,14 +220,14 @@ class Catalog:
         load it from configured sources if not already cached.
 
         Note that metaschemas that do not declare a known core vocabulary
-        in ``$vocabulary`` must first be created using :meth:`create_metaschema`.
+        in ``"$vocabulary"`` must first be created using :meth:`create_metaschema`.
 
         :param uri: the URI identifying the metaschema
 
         :raise CatalogError: if the object referenced by `uri` is not
             a :class:`~jschon.vocabulary.Metaschema`, or if it is not valid
         :raise JSONSchemaError: if the metaschema is loaded from sources
-            but no known core vocabulary is present in ``$vocabulary``
+            but no known core vocabulary is present in ``"$vocabulary"``
         """
         try:
             metaschema = self._schema_cache['__meta__'][uri]

--- a/jschon/catalog/__init__.py
+++ b/jschon/catalog/__init__.py
@@ -137,7 +137,7 @@ class Catalog:
 
         raise CatalogError(f'A source is not available for "{uri}"')
 
-    def create_vocabulary(self, uri: URI, *kwclasses: KeywordClass) -> None:
+    def create_vocabulary(self, uri: URI, *kwclasses: KeywordClass) -> Vocabulary:
         """Create a :class:`~jschon.vocabulary.Vocabulary` object, which
         may be used by a :class:`~jschon.vocabulary.Metaschema` to provide
         keyword classes used in schema construction.
@@ -145,8 +145,11 @@ class Catalog:
         :param uri: the URI identifying the vocabulary
         :param kwclasses: the :class:`~jschon.vocabulary.Keyword` classes
             constituting the vocabulary
+
+        :returns: the newly created :class:`Vocabulary` instance
         """
         self._vocabularies[uri] = Vocabulary(uri, *kwclasses)
+        return self._vocabularies[uri]
 
     def get_vocabulary(self, uri: URI) -> Vocabulary:
         """Get a :class:`~jschon.vocabulary.Vocabulary` by its `uri`.
@@ -162,23 +165,33 @@ class Catalog:
     def create_metaschema(
             self,
             uri: URI,
-            core_vocabulary_uri: URI,
+            default_core_vocabulary_uri: Optional[URI] = None,
             *default_vocabulary_uris: URI,
             **kwargs: Any,
-    ) -> None:
+    ) -> Metaschema:
         """Create, cache and validate a :class:`~jschon.vocabulary.Metaschema`.
 
         :param uri: the URI identifying the metaschema
-        :param core_vocabulary_uri: the URI identifying the metaschema's
-            core :class:`~jschon.vocabulary.Vocabulary`
+        :param default_core_vocabulary_uri: the URI identifying the metaschema's
+            core :class:`~jschon.vocabulary.Vocabulary`, used in the absence
+            of a ``"$vocabulary"`` keyword in the metaschema JSON file, or
+            if a known core vocabulary is not present under ``"$vocabulary"``
         :param default_vocabulary_uris: default :class:`~jschon.vocabulary.Vocabulary`
             URIs, used in the absence of a ``"$vocabulary"`` keyword in the
             metaschema JSON file
         :param kwargs: additional keyword arguments to pass through to the
             :class:`~jschon.jsonschema.JSONSchema` constructor
+
+        :returns: the newly created :class:`Metaschema` instance
+
+        :raise CatalogError: if the metaschema is not valid
         """
         metaschema_doc = self.load_json(uri)
-        core_vocabulary = self.get_vocabulary(core_vocabulary_uri)
+        default_core_vocabulary = (
+            self.get_vocabulary(default_core_vocabulary_uri)
+            if default_core_vocabulary_uri
+            else None
+        )
         default_vocabularies = [
             self.get_vocabulary(vocab_uri)
             for vocab_uri in default_vocabulary_uris
@@ -186,13 +199,38 @@ class Catalog:
         metaschema = Metaschema(
             self,
             metaschema_doc,
-            core_vocabulary,
+            default_core_vocabulary,
             *default_vocabularies,
             **kwargs,
             uri=uri,
         )
         if not metaschema.validate().valid:
-            raise CatalogError("The metaschema is invalid against itself")
+            raise CatalogError(
+                "The metaschema is invalid against its own metaschema "
+                f'"{metaschema_doc["$schema"]}"'
+            )
+        return metaschema
+
+    def get_metaschema(self, uri: URI) -> Metaschema:
+        """Get a metaschema identified by `uri` from a cache, or
+        load it from configured sources if not already cached.
+
+        Note that metaschemas that do not declare a known core vocabulary
+        in ``$vocabulary`` must first be created using :meth:`create_schema`.
+
+        :param uri: the URI identifying the metaschema
+
+        :raise CatalogError: if the object referenced by `uri` is not
+            a :class:`~jschon.vocabulary.Metaschema`, or if it is not valid
+        :raise JSONSchemaError: if the metaschema is loaded from sources
+            but no known core vocabulary is present in ``$vocabulary``
+        """
+        metaschema = self._schema_cache['__meta__'].get(uri)
+        if not metaschema:
+            metaschema = self.create_metaschema(uri)
+        if not isinstance(metaschema, Metaschema):
+            raise CatalogError(f"The schema referenced by {uri} is not a metaschema")
+        return metaschema
 
     def enable_formats(self, *format_attr: str) -> None:
         """Enable validation of the specified format attributes.

--- a/jschon/catalog/_next.py
+++ b/jschon/catalog/_next.py
@@ -99,14 +99,3 @@ def initialize(catalog: Catalog):
         ContentEncodingKeyword,
         ContentSchemaKeyword,
     )
-
-    catalog.create_metaschema(
-        URI("https://json-schema.org/draft/next/schema"),
-        URI("https://json-schema.org/draft/next/vocab/core"),
-        URI("https://json-schema.org/draft/next/vocab/applicator"),
-        URI("https://json-schema.org/draft/next/vocab/unevaluated"),
-        URI("https://json-schema.org/draft/next/vocab/validation"),
-        URI("https://json-schema.org/draft/next/vocab/format-annotation"),
-        URI("https://json-schema.org/draft/next/vocab/meta-data"),
-        URI("https://json-schema.org/draft/next/vocab/content"),
-    )

--- a/jschon/jsonschema.py
+++ b/jschon/jsonschema.py
@@ -221,8 +221,6 @@ class JSONSchema(JSON):
     @cached_property
     def metaschema(self) -> Metaschema:
         """The schema's :class:`~jschon.vocabulary.Metaschema`."""
-        from jschon.vocabulary import Metaschema
-
         if (uri := self.metaschema_uri) is None:
             raise JSONSchemaError("The schema's metaschema URI has not been set")
 

--- a/jschon/jsonschema.py
+++ b/jschon/jsonschema.py
@@ -218,7 +218,7 @@ class JSONSchema(JSON):
                 return parent
             parent = parent.parent
 
-    @property
+    @cached_property
     def metaschema(self) -> Metaschema:
         """The schema's :class:`~jschon.vocabulary.Metaschema`."""
         from jschon.vocabulary import Metaschema
@@ -226,13 +226,7 @@ class JSONSchema(JSON):
         if (uri := self.metaschema_uri) is None:
             raise JSONSchemaError("The schema's metaschema URI has not been set")
 
-        if not isinstance(
-                metaschema := self.catalog.get_schema(uri, cacheid='__meta__'),
-                Metaschema,
-        ):
-            raise JSONSchemaError(f"The schema referenced by {uri} is not a metachema")
-
-        return metaschema
+        return self.catalog.get_metaschema(uri)
 
     @property
     def metaschema_uri(self) -> Optional[URI]:

--- a/jschon/vocabulary/__init__.py
+++ b/jschon/vocabulary/__init__.py
@@ -32,7 +32,7 @@ class Metaschema(JSONSchema):
     :class:`Metaschema` is itself a subclass of :class:`~jschon.jsonschema.JSONSchema`,
     and may be used to validate any referencing schema.
     """
-    _CORE_VOCAB_RE = r'https://json-schema\.org/draft/[^/]*/vocab/core$'
+    _CORE_VOCAB_RE = r'https://json-schema\.org/draft/[^/]+/vocab/core$'
 
     def __init__(
             self,
@@ -45,9 +45,9 @@ class Metaschema(JSONSchema):
         """Initialize a :class:`Metaschema` instance from the given
         schema-compatible `value`.
 
-        :param catalog: catalog instance or catalog name
+        :param catalog: catalog instance
         :param value: a schema-compatible Python object
-        :param default_core_vocabulary: the the metaschema's
+        :param default_core_vocabulary: the metaschema's
             core :class:`~jschon.vocabulary.Vocabulary`, used in the absence
             of a ``"$vocabulary"`` keyword in the metaschema JSON file, or
             if a known core vocabulary is not present under ``"$vocabulary"``

--- a/jschon/vocabulary/__init__.py
+++ b/jschon/vocabulary/__init__.py
@@ -38,7 +38,7 @@ class Metaschema(JSONSchema):
             self,
             catalog: Catalog,
             value: Mapping[str, JSONCompatible],
-            default_core_vocabulary: Optional[Vocabulary] = None,
+            default_core_vocabulary: Vocabulary = None,
             *default_vocabularies: Vocabulary,
             **kwargs: Any,
     ):
@@ -118,6 +118,10 @@ class Vocabulary:
         self.kwclasses: Dict[str, KeywordClass] = {
             kwclass.key: kwclass for kwclass in kwclasses
         }
+
+    def __repr__(self) -> str:
+        """Return `repr(self)`."""
+        return f'{self.__class__.__name__}({self.uri!r})'
 
 
 class Keyword:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,6 +4,10 @@ metaschema_uri_2019_09 = URI("https://json-schema.org/draft/2019-09/schema")
 metaschema_uri_2020_12 = URI("https://json-schema.org/draft/2020-12/schema")
 metaschema_uri_next = URI("https://json-schema.org/draft/next/schema")
 
+core_vocab_uri_2019_09 = URI("https://json-schema.org/draft/2019-09/vocab/core")
+core_vocab_uri_2020_12 = URI("https://json-schema.org/draft/2020-12/vocab/core")
+core_vocab_uri_next = URI("https://json-schema.org/draft/next/vocab/core")
+
 example_schema = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "dynamicRef8_main.json",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def pytest_addoption(parser):
     )
 
 
-@pytest.fixture(scope='module', autouse=True)
+@pytest.fixture(autouse=True)
 def catalog():
     return create_catalog('2019-09', '2020-12', 'next')
 

--- a/tests/data/meta_invalid.json
+++ b/tests/data/meta_invalid.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/meta_invalid",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/core": true
+    },
+    "type": {"lol": "cats"}
+}

--- a/tests/data/meta_no_vocabs.json
+++ b/tests/data/meta_no_vocabs.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/meta_no_vocabs"
+}

--- a/tests/data/meta_with_core.json
+++ b/tests/data/meta_with_core.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/meta_with_core",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/core": true
+    }
+}

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -22,6 +22,22 @@ json_example = {"foo": "bar"}
 
 
 @pytest.fixture
+def local_catalog():
+    catalog = create_catalog(
+        '2019-09', '2020-12', 'next',
+        name='local'
+    )
+    catalog.add_uri_source(
+        URI('https://example.com/'),
+        LocalSource(
+            pathlib.Path(__file__).parent / 'data',
+            suffix='.json',
+        ),
+    )
+    return catalog
+
+
+@pytest.fixture
 def new_catalog() -> Catalog:
     return Catalog(name=str(uuid.uuid4()))
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -9,7 +9,7 @@ from jschon.vocabulary.format import FormatKeyword, format_validator
 from tests.strategies import jsonpointer
 
 
-@pytest.fixture(scope='module', autouse=True)
+@pytest.fixture(autouse=True)
 def setup_validators(catalog):
     catalog.enable_formats(
         "ipv4",

--- a/tests/test_metaschema.py
+++ b/tests/test_metaschema.py
@@ -1,0 +1,72 @@
+import pytest
+
+from jschon import JSONSchemaError, URI, create_catalog
+from jschon.vocabulary import Metaschema
+from tests import (
+    metaschema_uri_2020_12,
+    core_vocab_uri_2019_09, core_vocab_uri_2020_12, core_vocab_uri_next,
+)
+
+@pytest.mark.parametrize('vocab_data', [
+    None,
+    {
+        'https://example.com/whatever': True,
+    },
+    {
+        str(core_vocab_uri_2020_12): True,
+        str(core_vocab_uri_next): True,
+    },
+])
+def test_metaschema_no_core(vocab_data):
+    catalog = create_catalog('2019-09', '2020-12', 'next')
+
+    metaschema_id = 'https://example.com/no-core'
+    metaschema_data = {
+        '$schema': str(metaschema_uri_2020_12),
+        '$id': metaschema_id,
+    }
+    if vocab_data:
+        metaschema_data['$vocabulary'] = vocab_data
+        for vocab in vocab_data.keys() - set((
+            core_vocab_uri_2019_09,
+            core_vocab_uri_2020_12,
+            core_vocab_uri_next,
+        )):
+            catalog.create_vocabulary(URI(vocab))
+
+    with pytest.raises(JSONSchemaError):
+        Metaschema(catalog, metaschema_data, uri=URI(metaschema_id))
+
+def test_detect_core(catalog):
+    metaschema_id = 'https://example.com/meta'
+    metaschema_uri = URI(metaschema_id)
+    metaschema_data = {
+        '$schema': str(metaschema_uri_2020_12),
+        '$id': metaschema_id,
+        '$vocabulary': {
+            str(core_vocab_uri_2020_12): True,
+        },
+    }
+    m = Metaschema(catalog, metaschema_data, uri=metaschema_uri)
+
+    m1 = catalog._schema_cache['__meta__'][metaschema_uri]
+    m2 = catalog.get_metaschema(metaschema_uri)
+
+    assert m1 is m
+    assert m2 is m
+
+def test_default_core(catalog):
+    metaschema_id = 'https://example.com/meta'
+    metaschema_uri = URI(metaschema_id)
+    metaschema_data = {
+        '$schema': str(metaschema_uri_2020_12),
+        '$id': metaschema_id,
+    }
+    core = catalog.get_vocabulary(core_vocab_uri_2020_12)
+    m = Metaschema(
+        catalog,
+        metaschema_data,
+        core,
+        uri=metaschema_uri,
+    )
+    assert m.core_vocabulary is core

--- a/tests/test_metaschema.py
+++ b/tests/test_metaschema.py
@@ -27,11 +27,7 @@ def test_metaschema_no_core(vocab_data):
     }
     if vocab_data:
         metaschema_data['$vocabulary'] = vocab_data
-        for vocab in vocab_data.keys() - set((
-            core_vocab_uri_2019_09,
-            core_vocab_uri_2020_12,
-            core_vocab_uri_next,
-        )):
+        for vocab in vocab_data:
             catalog.create_vocabulary(URI(vocab))
 
     with pytest.raises(JSONSchemaError):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4,7 +4,7 @@ import pytest
 from hypothesis import given
 from pytest import param as p
 
-from jschon import JSON, JSONPointer, JSONSchema, URI
+from jschon import JSON, JSONPointer, JSONSchema, URI, create_catalog
 from jschon.json import false, true
 from tests import example_invalid, example_schema, example_valid, metaschema_uri_2019_09, metaschema_uri_2020_12
 from tests.strategies import *
@@ -54,8 +54,8 @@ def assert_keyword_order(keyword_list, keyword_pairs):
 
 
 @given(value=interdependent_keywords)
-def test_keyword_dependency_resolution_2019_09(value: list, catalog):
-    metaschema = catalog.get_schema(metaschema_uri_2019_09, cacheid='__meta__')
+def test_keyword_dependency_resolution_2019_09(value: list):
+    metaschema = create_catalog('2019-09').get_metaschema(metaschema_uri_2019_09)
     kwclasses = {
         key: kwclass for key in value if (kwclass := metaschema.kwclasses.get(key))
     }
@@ -96,8 +96,8 @@ def test_keyword_dependency_resolution_2019_09(value: list, catalog):
 
 
 @given(value=interdependent_keywords)
-def test_keyword_dependency_resolution_2020_12(value: list, catalog):
-    metaschema = catalog.get_schema(metaschema_uri_2020_12, cacheid='__meta__')
+def test_keyword_dependency_resolution_2020_12(value: list):
+    metaschema = create_catalog('2020-12').get_metaschema(metaschema_uri_2020_12)
     kwclasses = {
         key: kwclass for key in value if (kwclass := metaschema.kwclasses.get(key))
     }

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -3,7 +3,7 @@ import warnings
 
 import pytest
 
-from jschon import JSON, JSONSchema, LocalSource, URI, create_catalog
+from jschon import JSON, JSONSchema, LocalSource, URI
 from jschon.utils import json_loadf
 from tests import metaschema_uri_2019_09, metaschema_uri_2020_12, metaschema_uri_next
 
@@ -11,34 +11,10 @@ testsuite_dir = pathlib.Path(__file__).parent / 'JSON-Schema-Test-Suite'
 
 
 @pytest.fixture(autouse=True)
-def catalog():
-    # replaces the catalog fixture in conftest, for this test module
-    catalog = create_catalog(
-        '2019-09',
-        '2020-12',
-        'next',
-    )
+def setup_remotes(catalog):
     catalog.add_uri_source(
         URI('http://localhost:1234/'),
         LocalSource(testsuite_dir / 'remotes'),
-    )
-    catalog.create_metaschema(
-        URI('http://localhost:1234/draft2019-09/metaschema-no-validation.json'),
-        URI('https://json-schema.org/draft/2019-09/vocab/core'),
-        URI('https://json-schema.org/draft/2019-09/vocab/applicator'),
-        metaschema_uri=metaschema_uri_2019_09,
-    )
-    catalog.create_metaschema(
-        URI('http://localhost:1234/draft2020-12/metaschema-no-validation.json'),
-        URI('https://json-schema.org/draft/2020-12/vocab/core'),
-        URI('https://json-schema.org/draft/2020-12/vocab/applicator'),
-        metaschema_uri=metaschema_uri_2020_12,
-    )
-    catalog.create_metaschema(
-        URI('http://localhost:1234/draft-next/metaschema-no-validation.json'),
-        URI('https://json-schema.org/draft/next/vocab/core'),
-        URI('https://json-schema.org/draft/next/vocab/applicator'),
-        metaschema_uri=metaschema_uri_2020_12,
     )
 
 


### PR DESCRIPTION
Fixes #68 (2nd try, now with much more testing!) , although I'm submitting it as a draft to indicate that I'm not particularly confident that this is the ideal way to solve it. But it's a starting point, at least.

This change allows the tests added in PR json-schema-org/JSON-Schema-Test-Suite#646 (updated here in PR #67) to pass, in accordance with §9.3.1 of the spec, "Detecting a Meta-Schema".

* `Catalog.get_metaschema()` is added, and is analogous in behavior to `Catalog.get_schema()`, checking the `__meta__` cache directly and then relying on `Catalog.create_metaschema()` to avoid needlessly creating both `JSONSchema` and `Metaschema` instances.
* It is called from the now-cached `JSONSchema.metaschema` property, to keep the parallel with references which are only resolved when used.
* `Catalog.create_metaschema()` now returns the created metaschema to avoid having to immediately look it up again, as does `Catalog.create_vocabulary()`
* The `core_vocabulary` parameters have become `default_core_vocabulary` parameters to allow not knowing the core in advance
*The `Metaschema` constructor now looks in `"$vocabulary"` for a vocabulary URI matching `r'^https://json-schema\.org/draft/[^/]*/core$` and if it finds a unique match, uses that instead of the default
* Lack of a recognizable core vocabulary still results in a JSONSchemaError exception if no default is provided
* I wasn't entirely sure where to put the `Metaschema` test cases, so the `Catalog`-related ones went into that test file and the constructor ones went into a new `test_metaschema.py`

Note that the fixture is a separate commit because it is shared with the next PR I'm about to post.