### PR TITLE
Show filename from OSError when relevant

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Miscellaneous:
 * Rename submodules `json-schema-spec-2019-09` and `json-schema-spec-2020-12` to
   `json-schema-2019-09` and `json-schema-2020-12`, respectively
   (run ``git submodule init`` to update local git config)
+* LocalSource now includes the filename in the CatalogError when the file is not found
 
 
 v0.10.0 (2023-04-01)

--- a/jschon/catalog/__init__.py
+++ b/jschon/catalog/__init__.py
@@ -50,7 +50,7 @@ class LocalSource(Source):
                 # the exception args, which is what the Catalog
                 # puts in the CatalogError.  So it needs to be
                 # added separately for filesystem errors.
-                raise CatalogError(f'{e.strerror}: "{e.filename}"')
+                raise CatalogError(f'{e.strerror}: {e.filename!r}')
             raise
 
 

--- a/jschon/catalog/__init__.py
+++ b/jschon/catalog/__init__.py
@@ -42,7 +42,16 @@ class LocalSource(Source):
             filepath = str(filepath)
             filepath += self.suffix
 
-        return json_loadf(filepath)
+        try:
+            return json_loadf(filepath)
+        except OSError as e:
+            if e.filename is not None:
+                # The filename for OSError is not included in
+                # the exception args, which is what the Catalog
+                # puts in the CatalogError.  So it needs to be
+                # added separately for filesystem errors.
+                raise CatalogError(f'{e.strerror}: "{e.filename}"')
+            raise
 
 
 class RemoteSource(Source):
@@ -136,6 +145,8 @@ class Catalog:
             relative_path = uristr[len(base_uristr):]
             try:
                 return source(relative_path)
+            except CatalogError:
+                raise
             except Exception as e:
                 raise CatalogError(*e.args) from e
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -89,7 +89,7 @@ def test_local_source(base_uri, setup_tmpdir, new_catalog):
 def test_local_source_file_not_found(local_catalog):
     stem = 'not-there'
     fullname = str(pathlib.Path(__file__).parent / 'data' / f'{stem}.json')
-    with pytest.raises(CatalogError, match=f'"{re.escape(fullname)}"$'):
+    with pytest.raises(CatalogError, match=f"'{re.escape(fullname)}'$"):
         local_catalog.get_schema(URI(f'https://example.com/{stem}'))
 
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -6,6 +6,7 @@ import itertools
 import re
 
 import pytest
+from unittest.mock import patch
 
 from jschon import (
     Catalog,
@@ -90,6 +91,15 @@ def test_local_source_file_not_found(local_catalog):
     fullname = str(pathlib.Path(__file__).parent / 'data' / f'{stem}.json')
     with pytest.raises(CatalogError, match=f'"{re.escape(fullname)}"$'):
         local_catalog.get_schema(URI(f'https://example.com/{stem}'))
+
+
+def test_local_source_ioerror_no_file(local_catalog):
+    with patch('builtins.open') as m:
+        # This plain IOError will have an empty string as the message,
+        # without a filename that triggers different exception handling.
+        m.side_effect = IOError
+        with pytest.raises(CatalogError, match=r'^$'):
+            local_catalog.get_schema(URI('https://example.com/does-not-matter'))
 
 
 @pytest.mark.parametrize('base_uri', [

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -3,6 +3,7 @@ import pathlib
 import tempfile
 import uuid
 import itertools
+import re
 
 import pytest
 
@@ -82,6 +83,13 @@ def test_local_source(base_uri, setup_tmpdir, new_catalog):
     # incorrect file name
     with pytest.raises(CatalogError):
         new_catalog.load_json(URI(f'{base_uri}{subdir_name}/baz'))
+
+
+def test_local_source_file_not_found(local_catalog):
+    stem = 'not-there'
+    fullname = str(pathlib.Path(__file__).parent / 'data' / f'{stem}.json')
+    with pytest.raises(CatalogError, match=f'"{re.escape(fullname)}"$'):
+        local_catalog.get_schema(URI(f'https://example.com/{stem}'))
 
 
 @pytest.mark.parametrize('base_uri', [


### PR DESCRIPTION
For incomprehensible reasons apparently having to do with backwards compatibility, the filename parameter to `OSError` is not part of the `args` member, so the exception handling code that uses `args` to convert to a `CatalogError` was dropping  the rather important filename from the `FileNotFound` error.

Note that this PR shares the fixture commit with PR #71