### PR TITLE
Add document and resource rootschema properties

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Features:
 
 * ``JSONPointer`` and ``RelativeJSONPointer`` now have class attributes defining
   the exceptions that they use, which can be overidden in subclasses
+* Cached properties for accessing document and resource root schemas from subschemas
 
 
 v0.11.0 (2023-06-03)

--- a/jschon/jsonschema.py
+++ b/jschon/jsonschema.py
@@ -232,6 +232,35 @@ class JSONSchema(JSON):
             parent = parent.parent
 
     @cached_property
+    def resource_rootschema(self) -> JSONSchema:
+        """The :class:`JSONSchema` at the root of the containing resource.
+
+        This is the nearest ancestor (including `self`) containing ``"$id"``,
+        or if none exist, it is the same as `self.document_rootschema`.
+        """
+        if '$id' in self.keywords:
+            return self
+        ancestor = self
+        while ancestor.parentschema:
+            ancestor = ancestor.parentschema
+            if '$id' in ancestor.keywords:
+                return ancestor
+        return ancestor
+
+    @cached_property
+    def document_rootschema(self) -> JSONSchema:
+        """The :class:`JSONSchema` at the root of the entire document.
+
+        If no ancestor schemas contain ``"$id"``, this is the same as
+        `self.resource_rootschema`.  If this schema has no `self.parentschema`,
+        this method returns `self`.
+        """
+        ancestor = self
+        while ancestor.parentschema:
+            ancestor = ancestor.parentschema
+        return ancestor
+
+    @cached_property
     def metaschema(self) -> Metaschema:
         """The schema's :class:`~jschon.vocabulary.Metaschema`."""
         if (uri := self.metaschema_uri) is None:


### PR DESCRIPTION
_[**EDIT:** I figured out a much less convoluted way to handle #76, so this is no longer strictly necessary.  These accessors might be useful as part of the public API, so I'm leaving the PR up, but if they don't fit with the API design it's fine to just close this.]_

Finding the document root is needed for resolving references as proposed in order to support mutually referencing schema bundles per issue #76, but it stands on its own and the properties might be useful regardless of how that issue is (or isn't) solved.

The current proposal in #76 requires ensuring that either a schema document is all-resolved or all-not-resolved, to avoid unpredictable reference resolution errors during evaluation.  Exactly how and why this is needed will be more clear if/when I post a PR for the whole solution.