### PR TITLE
Expanded Catalog documentation

### DIFF
--- a/docs/tutorial/catalog.rst
+++ b/docs/tutorial/catalog.rst
@@ -20,7 +20,7 @@ at startup:
 The :func:`~jschon.create_catalog` function accepts a variable argument list
 indicating which versions of the JSON Schema vocabulary to support. For example,
 the following initialization call will enable our application to work with both
-2019-09 and 2020-12 schemas:
+2019-09 and 2020-12 schemas by pre-loading the metaschemas for both versions:
 
 >>> catalog = create_catalog('2019-09', '2020-12')
 
@@ -37,6 +37,9 @@ specified when creating new :class:`~jschon.jsonschema.JSONSchema` objects:
 >>> from jschon import JSONSchema
 >>> schema_1 = JSONSchema({"type": "object", ...}, catalog=catalog_1)
 >>> schema_2 = JSONSchema.loadf('/path/to/schema.json', catalog='Catalog 2')
+
+The :class:`~jschon.jsonschema.JSONSchema` constructor automatically uses
+the unnamed default catalog unless a different one is provided.
 
 .. _catalog-reference-loading:
 
@@ -61,12 +64,84 @@ Now, the ``"$ref"`` in the following schema resolves to the local file
     }
 
 We can also retrieve :class:`~jschon.jsonschema.JSONSchema` objects by URI
-directly from the catalog:
+directly from the catalog, using the same method that the catalog uses
+to resolve references:
 
 >>> my_schema = catalog.get_schema(URI("https://example.com/schemas/my/schema"))
 
 See :doc:`../examples/file_based_schemas` for further examples of loading
-schemas from disk.
+schemas from disk, and :mod:`jschon.catalog` for documentation on other
+possible sources.
+
+Schema and metaschema caching
+-----------------------------
+Whether a :class:`~jschon.jsonschema.JSONSchema` is instantiated directly or
+through :meth:`~jschon.catalog.Catalog.get_schema`, it is cached within its
+associated :class:`~jschon.catalog.Catalog` instance.
+
+The :class:`~jschon.catalog.Catalog` supports multiple caches, each using
+its own ``cacheid``, which can be provided as a parameter to the
+:class:`~jschon.jsonschema.JSONSchema` constructor and to methods
+such as :meth:`~jschon.jsonschema.Catalog.get_schema`.
+
+>>> from jschon import create_catalog, JSONSchema, URI, CatalogError
+>>> catalog = create_catalog('2020-12')
+>>> schema_data = {
+...     "$schema": "https://json-schema.org/draft/2020-12/schema",
+...     "$id": "https://example.com/foo",
+...     "type": "object"
+... }
+>>> schema_uri = URI(schema_data['$id'])
+>>> schema = JSONSchema(schema_data, cacheid='other')
+>>> cached = catalog.get_schema(URI(schema_data['$id']), cacheid='other')
+>>> cached is schema
+True
+
+Caches are isolated from each other, and references are only resolved within
+the same cache.  However, the same schema data can be instantiated as
+separate objects in different caches:
+
+>>> try:
+...     catalog.get_schema(schema_uri)
+... except CatalogError as e:
+...     print(f'{type(e).__name__}: {e}')
+CatalogError: A source is not available for "https://example.com/foo"
+>>> schema_in_default_cache = JSONSchema(schema_data)
+>>> cached_from_default = catalog.get_schema(schema_uri)
+>>> cached_from_default is schema_in_default_cache
+True
+>>> cached_from_default is cached
+False
+
+:class:`~jschon.vocabulary.Metaschema` instances are automatically cached
+separately from regular :class:`~jschon.jsonschema.JSONSchema` instances.
+This special metaschema cache is used by the
+:meth:`~jschon.jsonschema.JSONSchema.validate` method.  Catalogs constructed
+by the :func:`~jschon.create_metaschema` function have their metaschema cache
+automatically populated by the standard metaschemas for the JSON Schema
+version(s) passed to that function.
+
+>>> catalog_2019 = create_catalog('2019-09', name='2019-09 Catalog')
+>>> JSONSchema(
+...     {"$schema": "https://json-schema.org/draft/2019-09/schema"},
+...     catalog=catalog_2019
+... ).validate().valid
+True
+>>> try:
+...     JSONSchema(
+...         {"$schema": "https://json-schema.org/draft/2020-12/schema"},
+...         catalog=catalog_2019
+...     ).validate().valid
+... except CatalogError as e:
+...     print(f'{type(e).__name__}: {e}')
+CatalogError: A source is not available for "https://json-schema.org/draft/2020-12/schema"
+
+Metaschemas can also be added using the
+:meth:`~jschon.catalog.Catalog.create_metaschema` method.
+
+The metaschema cache and the :class:`~jschon.catalog.Source` configurations
+for a :class:`~jschon.catalog.Catalog` are shared across all of the regular
+:class:`~jschon.jsonschema.JSONSchema` caches within that catalog.
 
 Format validation
 -----------------

--- a/docs/tutorial/jsonschema.rst
+++ b/docs/tutorial/jsonschema.rst
@@ -23,6 +23,11 @@ For the examples shown on the remainder of this page, we'll use the following:
 >>> from jschon import create_catalog
 >>> catalog = create_catalog('2020-12')
 
+This creates a :class:`~jschon.catalog.Catalog` that automatically loads the
+the standard draft 2020-12 metaschema.  Since we did not pass a ``name`` parameter,
+this will be our default catalog that will be used automatically wherever a catalog
+is needed, unless we provide a different :class:`~jschon.catalog.Catalog` instance.
+
 Creating a schema
 -----------------
 There are several different ways to instantiate a :class:`~jschon.jsonschema.JSONSchema`:
@@ -144,6 +149,11 @@ Retrieving a schema from the catalog
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Finally, a :class:`~jschon.jsonschema.JSONSchema` object may be instantiated implicitly,
 when retrieving it by URI from the :class:`~jschon.catalog.Catalog`. If the schema is not
-already cached, it is loaded from disk and compiled on the fly. This approach requires
-the catalog to be configured with an appropriate base URI-to-directory mapping. For
-more information, see :ref:`catalog-reference-loading`.
+already cached, it is loaded from disk (or other configured sources) and compiled on the fly.
+
+This approach requires the catalog to be configured with an appropriate base
+URI-to-source mapping. Configuring a catalog in this way allows schema documents that
+reference each other to be created.  Otherwise, the :class:`~jschon.jsonschema.JSONSchema`
+constructor expects all referenced schemas to already be known to the catalog.
+
+For more information, see :ref:`catalog-reference-loading`.

--- a/jschon/__init__.py
+++ b/jschon/__init__.py
@@ -37,6 +37,10 @@ def create_catalog(*vocabularies: str, name: str = 'catalog') -> Catalog:
     initialized with a meta-schema and keyword support for each of the
     specified JSON Schema `vocabularies`.
 
+    The catalog created with the default name of ``'catalog'`` will
+    automatically be used wherevere a :class:`~jschon.catalog.Catalog`
+    instance is needed, unless a different instance is provided.
+
     :param vocabularies: Any of ``2019-09``, ``2020-12``, ``next``.
     :param name: A unique name for the :class:`~jschon.catalog.Catalog` instance.
     :raise ValueError: If any of `vocabularies` is unrecognized.

--- a/jschon/catalog/__init__.py
+++ b/jschon/catalog/__init__.py
@@ -24,15 +24,39 @@ __all__ = [
 
 
 class Source:
+    """The base class for sources to be used with :meth:`Catalog.add_uri_source`."""
     def __init__(self, suffix: str = None) -> None:
+        """Initialize a :class:`Source` instance.
+
+        :param suffix: a string such as ``.json`` to be appended to the
+            ``relative_path`` parameter to the :meth:`__call__` method.
+        """
         self.suffix = suffix
 
     def __call__(self, relative_path: str) -> JSONCompatible:
+        """Invoked to load a schema from this :class:`Source`.
+
+        :param relative_path: a URI reference relative to the ``base_uri``
+            parameter with which this :class:`Source` was registered using
+            :meth:`Catalog.add_uri_source`
+        :returns: The schema contents to be passed to the
+            :class:`~jschon.jsonschema.JSONSchema` constructor
+        """
         raise NotImplementedError
 
 
 class LocalSource(Source):
+    """A :class:`Source` that loads schema from a local filesystem."""
     def __init__(self, base_dir: Union[str, PathLike], **kwargs: Any) -> None:
+        """Initialize a :class:`LocalSource` instance.
+
+        :param base_dir: the local directory to which the ``relative_path``
+            parameter to the :meth:`__call__` method is appended, along
+            with the :data:`suffix` string, if any, to produce the schema
+            file name
+        :param kwargs: additional parameters to be passed to the base
+            class constructor
+        """
         super().__init__(**kwargs)
         self.base_dir = base_dir
 
@@ -46,7 +70,23 @@ class LocalSource(Source):
 
 
 class RemoteSource(Source):
+    """A :class:`Source` that loads schemas over HTTP(S).
+
+    As noted in the JSON Schema Core specificatoin, an ``http://`` or
+    ``https://`` URI does not necessarily mean that a referenced schema
+    is network-accessible, and care should be taken to avoid overloading
+    servers with requests for schemas.
+    """
     def __init__(self, base_url: URI, **kwargs: Any) -> None:
+        """Initialize a :class:`RemoteSource` instance.
+
+        :param base_url: a base URL against which the ``relative_path``
+            parameter to the :meth:`__call__` method is resolved, along
+            with the :data:`suffix` string, if any, to produce the schema
+            URL to retrieve
+        :param kwargs: additional parameters to be passed to the base
+            class constructor
+        """
         super().__init__(**kwargs)
         self.base_url = base_url
 
@@ -73,6 +113,12 @@ class Catalog:
 
     def __init__(self, name: str = 'catalog') -> None:
         """Initialize a :class:`Catalog` instance.
+
+        In most cases, the :func:`jschon.create_catalog` function should
+        be used instead of instantiating a :class:`Catalog` directly,
+        as it pre-populates the created catalog with the standard metaschemas
+        for the specified JSON Schema version(s).  Direct instantiation
+        is useful if only custom metaschemas will be used.
 
         :param name: a unique name for this :class:`Catalog` instance
         """
@@ -216,6 +262,12 @@ class Catalog:
             cacheid: Hashable = 'default',
     ) -> None:
         """Add a (sub)schema to a cache.
+
+        This method is intended for internal use.  Use the ``cacheid`` parameter
+        to :meth:`get-schema` or to the :class:`~jschon.jsonschema.JSONSchema`
+        constructor to instantiate a schema in a particular cache.  Adding a schema
+        to a cache other than the one with which it was constructed may produce
+        unexpected behavior.
 
         :param uri: the URI identifying the (sub)schema
         :param schema: the :class:`~jschon.jsonschema.JSONSchema` instance to cache


### PR DESCRIPTION
Document more about the behavior of create_catalog, schema and metaschema caching, and how the default catalog and cache are automatically used.

When I first started using `jschon`, I found the `Catalog` a bit confusing.  The general role was clear (and well-designed), but I couldn't understand why various examples showed `catalog = create_catalog(...)` and then the `catalog` variable not being used.  It took me a while to figure out how the catalog was being used behind the scenes, what it (or, technically, `create_catalog`) had to do with draft support, and how directly instantiated `JSONSchema` objects related to `Catalog`-created ones.

I've tried to make relatively minimal additions to the tutorials and the docstrings to cover the things that I would have found helpful to know.  I'm not attached to any of the details or wording here.

I've also added a few notes that I gleaned from looking through issues in this repo, such as advising against the use of `add_schema` or the direct use of the `Catalog` constructor.  I also documented the `Source` classes rather than trying to add information about `RemoteSource` or creating custom sources to the tutorials or examples.