### PR TITLE
Support discouraged but allowed "$id" values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,15 @@ Changelog
 
 v0.10.2 (in development)
 ------------------------
+Experimental:
+
+* "$id" no longer allows empty fragments in draft-next
+
+Bug Fixes:
+
+* "$id" allows non-normalized URI references
+* "$id" allows empty fragments in 2019-09 and 2020-12
+
 Miscellaneous:
 
 * Set default (2019-09, 2020-12) for ``--testsuite-version`` pytest option

--- a/jschon/catalog/_next.py
+++ b/jschon/catalog/_next.py
@@ -7,6 +7,7 @@ from jschon.vocabulary.applicator import *
 from jschon.vocabulary.core import *
 from jschon.vocabulary.format import *
 from jschon.vocabulary.validation import *
+from jschon.vocabulary.future import *
 
 
 def initialize(catalog: Catalog):
@@ -19,7 +20,7 @@ def initialize(catalog: Catalog):
         URI("https://json-schema.org/draft/next/vocab/core"),
         SchemaKeyword,
         VocabularyKeyword,
-        IdKeyword,
+        IdKeyword_Next,
         RefKeyword,
         AnchorKeyword,
         DynamicRefKeyword,

--- a/jschon/jsonschema.py
+++ b/jschon/jsonschema.py
@@ -125,9 +125,9 @@ class JSONSchema(JSON):
             raise TypeError(f"{value=} is not JSONSchema-compatible")
 
     def _bootstrap(self, value: Mapping[str, JSONCompatible]) -> None:
-        from jschon.vocabulary.core import IdKeyword, SchemaKeyword, VocabularyKeyword
+        from jschon.vocabulary.core import SchemaKeyword, VocabularyKeyword
+
         boostrap_kwclasses = {
-            "$id": IdKeyword,
             "$schema": SchemaKeyword,
             "$vocabulary": VocabularyKeyword,
         }
@@ -136,6 +136,19 @@ class JSONSchema(JSON):
                 kw = kwclass(self, value[key])
                 self.keywords[key] = kw
                 self.data[key] = kw.json
+
+        if "$id" in value:
+            if str(self.metaschema.core_vocabulary.uri) in (
+                "https://json-schema.org/draft/2019-09/vocab/core",
+                "https://json-schema.org/draft/2020-12/vocab/core",
+            ):
+                from jschon.vocabulary.core import IdKeyword
+            else:
+                from jschon.vocabulary.future import IdKeyword_Next as IdKeyword
+
+            id_kw = IdKeyword(self, value["$id"])
+            self.keywords["$id"] = id_kw
+            self.data["$id"] = id_kw.json
 
     def _resolve_references(self) -> None:
         for kw in self.keywords.values():

--- a/jschon/vocabulary/core.py
+++ b/jschon/vocabulary/core.py
@@ -69,7 +69,7 @@ class IdKeyword(Keyword):
     def __init__(self, parentschema: JSONSchema, value: str):
         super().__init__(parentschema, value)
 
-        (uri := URI(value)).validate(require_normalized=True, allow_fragment=False)
+        (uri := URI(value)).validate(allow_non_empty_fragment=False)
         if not uri.is_absolute():
             if (base_uri := parentschema.base_uri) is not None:
                 uri = uri.resolve(base_uri)

--- a/jschon/vocabulary/future.py
+++ b/jschon/vocabulary/future.py
@@ -1,0 +1,27 @@
+from typing import Mapping
+
+from jschon.exceptions import JSONSchemaError
+from jschon.jsonschema import JSONSchema
+from jschon.uri import URI
+from jschon.vocabulary import Keyword
+
+__all__ = [
+    'IdKeyword_Next',
+]
+
+
+class IdKeyword_Next(Keyword):
+    key = "$id"
+    static = True
+
+    def __init__(self, parentschema: JSONSchema, value: str):
+        super().__init__(parentschema, value)
+
+        (uri := URI(value)).validate(allow_fragment=False)
+        if not uri.is_absolute():
+            if (base_uri := parentschema.base_uri) is not None:
+                uri = uri.resolve(base_uri)
+            else:
+                raise JSONSchemaError(f'No base URI against which to resolve the "$id" value "{value}"')
+
+        parentschema.uri = uri

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -1,0 +1,47 @@
+import pytest
+
+from jschon import URIError, JSONSchema
+
+@pytest.mark.parametrize('draft', ('2019-09', '2020-12', 'next'))
+def test_non_normalized_id_allowed(draft):
+    schema_data = {
+        '$schema': f'https://json-schema.org/draft/{draft}/schema',
+        '$id': 'http://localhost:1234/foo/bar/../baz',
+    }
+    schema = JSONSchema(schema_data)
+    assert schema['$id'] == schema_data['$id']
+
+
+@pytest.mark.parametrize('draft', ('2019-09', '2020-12', 'next'))
+def test_nonempty_fragment_id_disallowed(draft):
+    schema_data = {
+        '$schema': f'https://json-schema.org/draft/{draft}/schema',
+        '$id': '#foo',
+    }
+    error = (
+        'has a non-empty fragment'
+        if draft in ['2019-09', '2020-12']
+        else 'has a fragment'
+    )
+    with pytest.raises(URIError, match=error):
+        JSONSchema(schema_data)
+
+
+@pytest.mark.parametrize('draft', ('2019-09', '2020-12'))
+def test_empty_fragment_id_allowed(draft):
+    schema_data = {
+        '$schema': f'https://json-schema.org/draft/{draft}/schema',
+        '$id': '/foo/bar#',
+    }
+    schema = JSONSchema(schema_data)
+    assert schema['$id'] == schema_data['$id']
+
+
+@pytest.mark.parametrize('draft', ('next',))
+def test_empty_fragment_id_disallowed(draft):
+    schema_data = {
+        '$schema': f'https://json-schema.org/draft/{draft}/schema',
+        '$id': '/foo/bar#',
+    }
+    with pytest.raises(URIError, match='has a fragment'):
+        JSONSchema(schema_data)


### PR DESCRIPTION
Fixes #69: Non-normalized URIs and (prior to draft-next) URis with empty fragments are allowed.  The official test suite does not pick up these issues, so additional tests have been included.