### PR TITLE
Allow deferring reference resolution to support mutually referencing bundles

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,14 +3,12 @@ Changelog
 
 v0.11.1 (in development)
 ------------------------
-Features:
+Bug Fixes:
 
 * Allow adding a source with a base URI of ``None`` to match full URIs as the ``relative_path``
 * ``JSONPointer`` and ``RelativeJSONPointer`` now have class attributes defining
   the exceptions that they use, which can be overidden in subclasses
 * Cached properties for accessing document and resource root schemas from subschemas
-* Support mutually referencing embedded subschema resources with the
-  ``resolve_references`` constructor parameter and method for ``JSONSchema``.
 * Support mutually referencing embedded subschema resources with the
   ``resolve_references`` constructor parameters and methods on
   ``JSONSchema``, ``Catalog``, and ``create_catalog``.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,9 @@ Features:
 * Cached properties for accessing document and resource root schemas from subschemas
 * Support mutually referencing embedded subschema resources with the
   ``resolve_references`` constructor parameter and method for ``JSONSchema``.
+* Support mutually referencing embedded subschema resources with the
+  ``resolve_references`` constructor parameters and methods on
+  ``JSONSchema``, ``Catalog``, and ``create_catalog``.
 
 
 v0.11.0 (2023-06-03)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Features:
 * ``JSONPointer`` and ``RelativeJSONPointer`` now have class attributes defining
   the exceptions that they use, which can be overidden in subclasses
 * Cached properties for accessing document and resource root schemas from subschemas
+* Support mutually referencing embedded subschema resources with the
+  ``resolve_references`` constructor parameter and method for ``JSONSchema``.
 
 
 v0.11.0 (2023-06-03)

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -6,3 +6,4 @@ Tutorial
     tutorial/jsonpointer
     tutorial/jsonschema
     tutorial/catalog
+    tutorial/referencing

--- a/docs/tutorial/referencing.rst
+++ b/docs/tutorial/referencing.rst
@@ -64,3 +64,50 @@ We could have deferred reference resolution on both schemas, and then called
 But since ``schema1`` was already present in the catalog, the catalog was
 already aware of the ``"$id"`` URIs needed to resolve references for ``schema2``.
 
+Deferring through the Catalog
+-----------------------------
+If schemas such as our mutually referencing bundles are being loaded through
+the :class:`~jschon.catalog.Catalog`, we need to configure the catalog to
+defer resolution on all loaded schemas.  This can be done through
+:func:`jschon.create_catalog`:
+
+>>> from jschon import create_catalog, URI, LocalSource
+>>> deferred_catalog = create_catalog('2020-12', name='deferred', resolve_references=False)
+>>> deferred_catalog.add_uri_source(
+...     URI('https://example.com/'),
+...     LocalSource(base_dir='/opt/schemas/', suffix='.json'),
+... )
+>>> cat_bundle1 = deferred_catalog.get_schema(URI("https://example.com/bundle1"))
+>>> cat_bundle2 = deferred_catalog.get_schema(URI("https://example.com/bundle2"))
+>>> cat_bundle1.references_resolved
+False
+>>> cat_bundle2.references_resolved
+False
+
+We can use the :meth:`jschon.catalog.Catalog.resolve_references` convenience
+method to resolve all references in all schemas in a particular schema cache.
+We are using the default cache here so we do not need to pass a ``cacheid``:
+
+>>> deferred_catalog.resolve_references()
+>>> cat_bundle1.references_resolved
+True
+>>> cat_bundle2.references_resolved
+True
+
+You can access this method through a :class:`~jschon.jsonschema.JSONSchema`
+instance, in which case it is a good idea to pass the ``cacheid`` unless you
+are certain the schema is using the default cache:
+
+>>> cat_bundle1.catalog.resolve_references(cacheid=cat_bundle1.cacheid)
+
+Note that resolving references may cause additional schemas to be loaded.
+:meth:`~jschon.catalog.Catalog.resolve_references` will resolve references
+in newly loaded schemas as well, until either the entire schema cache is
+fully resolved as it would have been without deferral, or an error occurs.
+
+Metaschemas and deferred resolution
+-----------------------------------
+The :meth:`~jschon.catalog.Catalog.create_metaschema` method validates
+the metaschema when it is created.  Therefore it also resolves references
+in the metaschema cache just prior to calling
+:meth:`~jschon.vocabulary.Metaschema.validate`.

--- a/docs/tutorial/referencing.rst
+++ b/docs/tutorial/referencing.rst
@@ -1,0 +1,66 @@
+Advanced Referencing
+====================
+The vast majority of referencing scenarios can be handled as described in the
+earlier parts of this tutorial.  However, consider the following
+`schema bundles <https://www.ietf.org/archive/id/draft-bhutton-json-schema-01.html#name-bundling>`_:
+
+>>> bundle1 = {
+...     "$schema": "https://json-schema.org/draft/2020-12/schema",
+...     "$id": "https://example.com/bundle1",
+...     "$defs": {
+...         "a": {
+...             "$id": "https://example.com/source1/a",
+...             "$ref": "../source2/b"
+...         },
+...         "b": {
+...             "$id": "https://example.com/source1/b",
+...             "type": "object"
+...         }
+...     }
+... }
+>>> bundle2 = {
+...     "$schema": "https://json-schema.org/draft/2020-12/schema",
+...     "$id": "https://example.com/bundle2",
+...     "$defs": {
+...         "a": {
+...             "$id": "https://example.com/source2/a",
+...             "$ref": "../source1/b"
+...         },
+...         "b": {
+...             "$id": "https://example.com/source2/b",
+...             "type": "array"
+...         }
+...     }
+... }
+
+There are several conditions here, including one not visible in the schemas
+but plausible in many software environments:
+
+* Mutual references (which the normal :class:`~jschon.jsonschema.JSONSchema`
+  constructor call cannot handle)
+* References only to URIs from subschema ``"$id"`` keywords (which the normal
+  :class:`~jschon.catalog.LocalSource` or :class:`~jschon.catalog.RemoteSource`
+  configurations cannot handle)
+* Your code may need to handle schemas with contents that it does not know
+  in advance.  (which prevents creative use of a :class:`~jschon.catalog.Source`
+  subclass to map the subschema ``"$id"`` URIs to their top-level ``"$id"``
+  in some way, assuming that the top-level ``"$id"`` would normally be findable)
+
+Together, these conditions require an extra step to manage.
+
+Deferring reference resolution
+------------------------------
+Reference resolution can be deferred using a :class:`~jschon.jsonschema.JSONSchema`
+constructor parameter.  Deferred references **must** be resolved by calling
+:meth:`~jschon.jsonschema.JSONSchema.resolve_references` prior to calling
+:meth:`~jschon.jsonschema.JSONSchema.evaluate`:
+
+>>> schema1 = JSONSchema(bundle1, resolve_references=False)
+>>> schema2 = JSONSchema(bundle2)
+>>> schema1.resolve_references()
+
+We could have deferred reference resolution on both schemas, and then called
+:meth:`~jschon.jsonschema.JSONSchema.resolve_references` on both of them.
+But since ``schema1`` was already present in the catalog, the catalog was
+already aware of the ``"$id"`` URIs needed to resolve references for ``schema2``.
+

--- a/jschon/__init__.py
+++ b/jschon/__init__.py
@@ -25,18 +25,27 @@ __all__ = [
 __version__ = '0.11.1'
 
 
-def create_catalog(*versions: str, name: str = 'catalog') -> Catalog:
+def create_catalog(
+    *versions: str,
+    name: str = 'catalog',
+    resolve_references: bool = True
+) -> Catalog:
     """Create and return a :class:`~jschon.catalog.Catalog` instance,
     initialized with a meta-schema and keyword support for each of the
     specified JSON Schema `versions`.
 
     :param versions: Any of ``2019-09``, ``2020-12``, ``next``.
     :param name: A unique name for the :class:`~jschon.catalog.Catalog` instance.
+    :param resolve_references: Passed through to any calls made to the
+        :class:`~jschon.jsonschema.JSONSchema` constructor; defaults to ``True``;
+        if set to ``False`` a separate call to
+        :meth:`~jschon.catalog.Catalog.resolve_references` is required prior to
+        evaluating any schemas.
     :raise ValueError: If any of `versions` is unrecognized.
     """
     from .catalog import _2019_09, _2020_12, _next
 
-    catalog = Catalog(name=name)
+    catalog = Catalog(name=name, resolve_references=resolve_references)
 
     version_initializers = {
         '2019-09': _2019_09.initialize,

--- a/jschon/jsonschema.py
+++ b/jschon/jsonschema.py
@@ -55,8 +55,8 @@ class JSONSchema(JSON):
             references; set to ``False`` when a schema with a temporarily
             unresolvable reference needs to be instantiated — references MUST
             be resolved prior to evaluation by calling by calling :meth:`resolve_references`
-            on each unresolved schema once all reference target schemas are
-            in the relevant :class:`~jschon.catalog.Catalog`'s schema cache
+            on each unresolved schema, or :meth:`~jschon.catalog.Catalog.resolve_references`
+            on the relevant catalog.
         """
         from jschon.catalog import Catalog
 

--- a/jschon/jsonschema.py
+++ b/jschon/jsonschema.py
@@ -221,7 +221,13 @@ class JSONSchema(JSON):
         :param instance: the JSON document to evaluate
         :param result: the current result node; given by keywords
             when invoking this method recursively
+        :raises JSONSchemaError: if references have not yet been resolved;
+            by default references are resolved during construction
         """
+        if self.references_resolved is False:
+            raise JSONSchemaError(
+                'resolve_references() must be called before evaluate()'
+            )
         if result is None:
             result = Result(self, instance)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -42,3 +42,45 @@ example_schema = {
 }
 example_valid = {"alpha": 1.1}
 example_invalid = {"november": 1.1}
+
+
+schema_bundle1 = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/bundle1",
+    "$defs": {
+        "a": {
+            "$id": "https://example.com/source1/a",
+            "$ref": "../source2/b#/$defs/inner",
+        },
+        "b": {
+            "$id": "https://example.com/source1/b",
+            "$dynamicAnchor": "here",
+            "type": "object",
+            "$defs": {
+                "inner": {
+                    "$dynamicRef": "#here",
+                },
+            },
+        },
+    },
+}
+schema_bundle2 = {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://example.com/bundle2",
+    "$defs": {
+        "a": {
+            "$id": "https://example.com/source2/a",
+            "$ref": "../source1/b#/$defs/inner",
+        },
+        "b": {
+            "$id": "https://example.com/source2/b",
+            "$recursiveAnchor": True,
+            "type": "array",
+            "$defs": {
+                "inner": {
+                    "$recursiveRef": "#"
+                }
+            }
+        },
+    },
+}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4,7 +4,8 @@ import pytest
 from hypothesis import given
 from pytest import param as p
 
-from jschon import JSON, JSONPointer, JSONSchema, URI, CatalogError, create_catalog
+from jschon import \
+    JSON, JSONPointer, JSONSchema, JSONSchemaError, URI, CatalogError, create_catalog
 from jschon.json import false, true
 from tests import example_invalid, example_schema, example_valid, \
     metaschema_uri_2019_09, metaschema_uri_2020_12, schema_bundle1, schema_bundle2
@@ -109,7 +110,7 @@ def test_deferred_ref_resolution():
 
     assert bundle1.references_resolved is False
     assert bundle2.references_resolved is False
-    with pytest.raises(AttributeError):
+    with pytest.raises(JSONSchemaError, match='resolve_references'):
         bundle1['$defs']['a'].evaluate(JSON([]))
 
     ref1 = bundle1['$defs']['a'].keywords['$ref']
@@ -133,7 +134,7 @@ def test_deferred_ref_resolution():
         assert kwd.refschema is None
         with pytest.raises(AttributeError):
             kwd.evaluate(kwd.parentschema, JSON({}))
-    with pytest.raises(AttributeError):
+    with pytest.raises(JSONSchemaError, match='resolve_references'):
         bundle1['$defs']['a'].evaluate(JSON([]))
 
     bundle2.resolve_references()


### PR DESCRIPTION
**EDIT:** As a complement or alternative to this PR, PRs #83 and #85 provide near-parity with the status quo for complex mutual references including bundles — this PR adds the ability to handle sets of schemas where:

* the `"$id"` contents are not known in advance, preventing configuration of a `Source` to retrieve them
* mutual references are present, preventing direct instantiation

The sources added in PR #85 can be complex to configure, so despite this PR's own complexity, it offers an easier way to manage certain scenarios.

In particular, it enables building _generic schema-oriented tools_ that will have to work with arbitrary sets of schemas provided by whatever code calls the tools (this is the use case that is of particular interest to me, as someone who mostly works on generic tools).

-------
Original comment for this PR:'

Fixes #76, preserving backwards compatibility and the guarantee that schemas will not encounter a reference resolution error when evaluated.

* Add `resolve_references` parameter to `JSONSchema.__init__()`, `Catalog.__init__()`, and `create_catalog`(), with the latter two passing through the value to the former whenever relevant.  All default to `True`, preserving the current behavior
* Add a `JSONSchema.references_resolved` data member to track the resolution state
* Promote `JSONSchema._resolve_references()` to a public method `JSONSchema.resolve_references, which checks `self.references_resolved` to avoid a very expensive no-op if called twice
* Add `Catalog.resolve_references()` to resolve all references within a cache, including resolving references to schemas added to the cache during reference resolution, iterating until all are resolved; it takes an optional `cacheid` parameter with the usual defaulting behavior
* Check `self.references_resolved` in `JSONSchema.evaluate()` and raise a `JSONSchemaError` if references have not been resolved

For more details on usage, see the added tutorial page.  This PR contains three commits:

1.  Adding the basic `JSONSchema` behavior, except for the change to `evaluate()` — this is the fundamental approach, and is sufficient for technical compliance.  However, it is not very convenient in many ways
2. Adding the `Catalog` behavior, allowing dynamic loading to use this behavior, and allowing a schema cache-level resolution to bring a cache into alignment with how it would be if the normal reference resolution had taken place — this provides all the tools necessary to replicate the current experience as a two-step rather than one-step process
3. Add the `JSONSchemaError` if `evaluate()` is called with unresolved references

It would be trivial to replace commit 3 with a call to the catalog's schema cache-level `resolve_references()`, and I have that available and tested if that behavior would be preferred.  It would mean that `evaluate()` could raise a `CatalogError` on the first invocation, which seemed like a bigger change.  Plus the first `evaluate()` would be much slower.  So I went with this more explicit approach.

At one point, in the 2nd commit I had the catalog tracking which schemas were and were not resolved, but this introduced substantial complexity to the code so I dropped it.  I can post it as an alternative if desired.  I suspect the performance was worse, except possibly in the case where a very large schema cache has a very small number of unresolved schemas, in which case the PR as written will spend extra time needlessly calling `resolve_references()` on a lot of schemas.  But this is probably rare.

At an earlier point, I tried to make a call to `JSONSchema.resolve_references()` cascade through its keywords to resolve any schemas that it referenced, etc.  This was even more complicated (and required #78, which this current PR does not), so I dropped it.  Again, I can post it as an alternative if desired.

As it stands, this PR is the most minimal way I could think of to satisfy the specification requirements regarding bundled schemas.