### PR TITLE
Allow adding a default source with a base URI of None

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ v0.11.1 (in development)
 ------------------------
 Features:
 
+* Allow adding a source with a base URI of ``None`` to match full URIs as the ``relative_path``
 * ``JSONPointer`` and ``RelativeJSONPointer`` now have class attributes defining
   the exceptions that they use, which can be overidden in subclasses
 * Cached properties for accessing document and resource root schemas from subschemas

--- a/jschon/catalog/__init__.py
+++ b/jschon/catalog/__init__.py
@@ -90,7 +90,7 @@ class Catalog:
         self.name: str = name
         """The unique name of this :class:`Catalog` instance."""
 
-        self._uri_sources: Dict[URI, Source] = {}
+        self._uri_sources: Dict[str, Source] = {}
         self._vocabularies: Dict[URI, Vocabulary] = {}
         self._schema_cache: Dict[Hashable, Dict[URI, JSONSchema]] = {}
         self._enabled_formats: Set[str] = set()
@@ -99,23 +99,27 @@ class Catalog:
         """Return `repr(self)`."""
         return f'{self.__class__.__name__}({self.name!r})'
 
-    def add_uri_source(self, base_uri: URI, source: Source) -> None:
+    def add_uri_source(self, base_uri: Union[URI, None], source: Source) -> None:
         """Register a source for loading URI-identified JSON resources.
 
         :param base_uri: a normalized, absolute URI - including scheme, without
-            a fragment, and ending with ``'/'``
+            a fragment, and ending with ``'/'`` or None to match all complete URIs
         :param source: a :class:`Source` object
         :raise CatalogError: if `base_uri` is invalid
         """
-        try:
-            base_uri.validate(require_scheme=True, require_normalized=True, allow_fragment=False)
-        except URIError as e:
-            raise CatalogError from e
+        if base_uri is None:
+            prefix = ''
+        else:
+            try:
+                base_uri.validate(require_scheme=True, require_normalized=True, allow_fragment=False)
+            except URIError as e:
+                raise CatalogError from e
 
-        if not base_uri.path or not base_uri.path.endswith('/'):
-            raise CatalogError('base_uri must end with "/"')
+            if not base_uri.path or not base_uri.path.endswith('/'):
+                raise CatalogError('base_uri must end with "/"')
+            prefix = str(base_uri)
 
-        self._uri_sources[base_uri] = source
+        self._uri_sources[prefix] = source
 
     def load_json(self, uri: URI) -> JSONCompatible:
         """Load a JSON-compatible object from the source for `uri`.
@@ -135,14 +139,14 @@ class Catalog:
 
         uristr = str(uri)
         candidates = [
-            (base_uristr, source)
-            for base_uri, source in self._uri_sources.items()
-            if uristr.startswith(base_uristr := str(base_uri))
+            (prefix, source)
+            for prefix, source in self._uri_sources.items()
+            if uristr.startswith(prefix)
         ]
         if candidates:
             candidates.sort(key=lambda c: len(c[0]), reverse=True)
-            base_uristr, source = candidates[0]
-            relative_path = uristr[len(base_uristr):]
+            prefix, source = candidates[0]
+            relative_path = uristr[len(prefix):]
             try:
                 return source(relative_path)
             except CatalogError:

--- a/jschon/catalog/__init__.py
+++ b/jschon/catalog/__init__.py
@@ -102,8 +102,11 @@ class Catalog:
     def add_uri_source(self, base_uri: Union[URI, None], source: Source) -> None:
         """Register a source for loading URI-identified JSON resources.
 
+        A base URI of ``None`` registers a default source that handles any
+        URI that does not match any registered base URI string.
+
         :param base_uri: a normalized, absolute URI - including scheme, without
-            a fragment, and ending with ``'/'`` or None to match all complete URIs
+            a fragment, and ending with ``'/'`` or None to match complete URIs
         :param source: a :class:`Source` object
         :raise CatalogError: if `base_uri` is invalid
         """
@@ -111,7 +114,11 @@ class Catalog:
             prefix = ''
         else:
             try:
-                base_uri.validate(require_scheme=True, require_normalized=True, allow_fragment=False)
+                base_uri.validate(
+                    require_scheme=True,
+                    require_normalized=True,
+                    allow_fragment=False,
+                )
             except URIError as e:
                 raise CatalogError from e
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -27,23 +27,19 @@ json_example = {"foo": "bar"}
 
 
 @pytest.fixture
-def empty_catalog():
-    return create_catalog(
+def local_catalog():
+    catalog = create_catalog(
         '2019-09', '2020-12', 'next',
         name='local'
     )
-
-
-@pytest.fixture
-def local_catalog(empty_catalog):
-    empty_catalog.add_uri_source(
+    catalog.add_uri_source(
         URI('https://example.com/'),
         LocalSource(
             pathlib.Path(__file__).parent / 'data',
             suffix='.json',
         ),
     )
-    return empty_catalog
+    return catalog
 
 
 @pytest.fixture
@@ -113,7 +109,7 @@ def test_local_source_ioerror_no_file(local_catalog):
             local_catalog.get_schema(URI('https://example.com/does-not-matter'))
 
 
-def test_default_source(empty_catalog):
+def test_default_source(local_catalog):
     class FullURISource(Source):
         def __call__(self, relative_path):
             URI(relative_path).validate(require_scheme=True)
@@ -124,8 +120,8 @@ def test_default_source(empty_catalog):
 
     id_str = 'tag:jschon.dev,2023-03:schema'
 
-    empty_catalog.add_uri_source(None, FullURISource())
-    schema = empty_catalog.get_schema(URI(id_str))
+    local_catalog.add_uri_source(None, FullURISource())
+    schema = local_catalog.get_schema(URI(id_str))
     assert schema['$id'].data == id_str
 
 


### PR DESCRIPTION
Minimally fixes #75.  This can be used to match complete URIs, particularly URN-ish URIs using schemes that do not readily break down into a base and a relative reference.

The details of the change (using a string prefix after verifying the base URI when it is not `None`) is invisible to the public API, and the fundamental semantics are preserved.

This is sufficient for the use case that was blocking me:  how to load a URI like `tag:modern-json-schema.com,2023-03:something`, which cannot be split.  Its only components are the scheme `tag` and the path `modern-json-schema.con,2023-03:something`, and that path cannot be used as the start of a relative reference because it contains a `:`.

## Potential workarounds

An alternative would be to register a source for each expected URI using the whole URI as a base URI, but that wouldn't work for URIs not known in advance.

## Discarded approaches

I attempted the more flexible `uri_prefix` idea proposed in #75, but it became complicated and required awkward contortions to maintain backwards compatibility in the public API.  I decided that the extra flexibility was not worthwhile as a source registered in this way can do whatever re-mapping it wants with the `relative_path`, such as converting `:` characters to something else so that the URI can be used on Mac OS X filesystems.