### PR TITLE
"integer" is not a keyword restriction type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Miscellaneous:
 * Rename submodules `json-schema-spec-2019-09` and `json-schema-spec-2020-12` to
   `json-schema-2019-09` and `json-schema-2020-12`, respectively
   (run ``git submodule init`` to update local git config)
+* ``integer`` is no longer considered a type for keyword evaluation restriction purposes
 
 
 v0.10.0 (2023-04-01)

--- a/jschon/vocabulary/__init__.py
+++ b/jschon/vocabulary/__init__.py
@@ -127,7 +127,7 @@ class Vocabulary:
 class Keyword:
     key: str = ...
 
-    instance_types: Tuple[str, ...] = "null", "boolean", "integer", "number", "string", "array", "object",
+    instance_types: Tuple[str, ...] = "null", "boolean", "number", "string", "array", "object",
     """The types of instance that the keyword can evaluate."""
 
     depends_on: Tuple[str, ...] = ()
@@ -147,13 +147,7 @@ class Keyword:
         self.parentschema: JSONSchema = parentschema
 
     def can_evaluate(self, instance: JSON) -> bool:
-        if instance.type in self.instance_types:
-            return True
-
-        if instance.type == "number" and "integer" in self.instance_types:
-            return instance.data == int(instance.data)
-
-        return False
+        return instance.type in self.instance_types
 
     def evaluate(self, instance: JSON, result: Result) -> None:
         pass


### PR DESCRIPTION
Fixes #81, if there's a desire to "fix" it:  Keywords can only be restricted to JSON data model types.

The extension keyword API is not an area where people test for compliance, so I'd be equally happy with documenting that `"integer"` as an evaluation restriction is a `jschon` extension, and could post a PR for that if desired.  I would also not be upset if this and #81 are just closed and things are left as-is.