### PR TITLE
Additional/alternative support for complex references

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Features:
 * ``JSONPointer`` and ``RelativeJSONPointer`` now have class attributes defining
   the exceptions that they use, which can be overidden in subclasses
 * Cached properties for accessing document and resource root schemas from subschemas
+* Added ``RewritingLocalSource`` and ``RewritingRemoteSource`` for complex reference mapping
 
 
 v0.11.0 (2023-06-03)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,6 +10,8 @@ Catalog
 * :class:`~jschon.catalog.Catalog`
 * :class:`~jschon.catalog.LocalSource`
 * :class:`~jschon.catalog.RemoteSource`
+* :class:`~jschon.catalog.RewritingLocalSource`
+* :class:`~jschon.catalog.RewritingRemoteSource`
 
 JSON
 ^^^^

--- a/jschon/__init__.py
+++ b/jschon/__init__.py
@@ -1,4 +1,4 @@
-from .catalog import Catalog, LocalSource, RemoteSource
+from .catalog import Catalog, LocalSource, RemoteSource, RewritingLocalSource, RewritingRemoteSource
 from .exceptions import CatalogError, JSONError, JSONPatchError, JSONPointerError, JSONSchemaError, URIError
 from .json import JSON, JSONCompatible
 from .jsonpatch import JSONPatch, JSONPatchOperation
@@ -18,6 +18,8 @@ __all__ = [
     'RelativeJSONPointer',
     'RemoteSource',
     'Result',
+    'RewritingLocalSource',
+    'RewritingRemoteSource',
     'URI',
     'create_catalog',
 ]

--- a/jschon/catalog/__init__.py
+++ b/jschon/catalog/__init__.py
@@ -104,7 +104,8 @@ class RewritingSourceMixin(Source):
             callables used in this way should return the original
             value if they do not understand how to rewrite it
         """
-        self._rewrite_map = rewrite_map or {}
+        # Make a copy to avoid unexpected changes
+        self._rewrite_map = dict(rewrite_map) if rewrite_map else {}
         self._rewrite_call = rewrite_call
         super().__init__(*args, **kwargs)
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -208,6 +208,19 @@ def test_remote_source(
         new_catalog.load_json(URI(f'{base_uri}baz/quuz'))
 
 
+def test_rewriting_source_map_frozen():
+    rewrite_map = {'a': 1, 'b': 2}
+    source = RewritingLocalSource(
+        pathlib.Path('.').resolve(),
+        rewrite_map=rewrite_map,
+    )
+    original_map = rewrite_map.copy()
+    del rewrite_map['a']
+
+    assert source._rewrite_map != rewrite_map
+    assert source._rewrite_map == original_map
+
+
 @pytest.mark.parametrize('base_uri', [
     '//example.com/foo/bar/',  # no scheme
     'http://Example.com/foo/bar/',  # not normalized


### PR DESCRIPTION
The combination of this PR and PR #83 mostly fixes #76, although one use case still requires PR #82.  This PR and #83 require more work on the part of the caller to configure sources, and require that the relationship between source file names or URLs and the `"$id"` URIs, such as embedded subschema `"$id"` URIs, be known in advance.

This PR adds a `RewritingSourceMixin` class, which allows constructing sources that rewrite the URIs requested so that the URI structure and storage layout can have a more complex relationship.

This particularly facilitates references to schema resources embedded in bundles, or references to URI components that use characters not allowed in filesystems, or a unified URI namespace that is distributed across multiple repositories in a test environment.

The `RewritingLocalSource` and `RewritingRemoteSource` simply add the new functionality to the two existing sources.  The relevance of PR #83 is that it enables arbitrary rewriting, instead of restricting the rewriting only to valid relative URI-references.