### PR TITLE
Allow changing "$schema" in embedded resources

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Features:
 * Allow adding a source with a base URI of ``None`` to match full URIs as the ``relative_path``
 * ``JSONPointer`` and ``RelativeJSONPointer`` now have class attributes defining
   the exceptions that they use, which can be overidden in subclasses
+* ``"$schema"`` can change value in subschemas that have an ``"$id"``
 * Cached properties for accessing document and resource root schemas from subschemas
 
 


### PR DESCRIPTION
Fixes #59.  Ultimately this was surprisingly simple (unlike several of my early attempts at it 😅 ).

As of draft 2020-12, embedded schemas (subschemas with "$id") can set "$schema" to something different from their containing resource.

2019-09 allows the presence of "$schema" in such circumstances, but leaves the behavior up to the implementation if the value differs from the containing resource.  This change allows "$schema" switching to behave the same in 2019-09 as in 2020-12.

The change adds a `validating_with` parameter to the `Result` constructor and `__call__` methods, which is set by `JSONSchema.validate()` to indicate that the evaluation is evaluating a schema against its metaschema, rather than a normal evaluation.

`JSONSchema.evaluate()` checks `result.validating_with`, and if all of the conditions are met, changes the evaluating schema from `self` to the schema-as-instance's metaschema before proceeding as normal.  The original `self` schema, whether boolean or object, is not applied at all.