### PR TITLE
More info about the Catalog in the tutorial

### DIFF
--- a/docs/tutorial/catalog.rst
+++ b/docs/tutorial/catalog.rst
@@ -20,7 +20,7 @@ at startup:
 The :func:`~jschon.create_catalog` function accepts a variable argument list
 indicating which versions of the JSON Schema vocabularies to support. For example,
 the following initialization call will enable your application to work with both
-2019-09 and 2020-12 schemas:
+2019-09 and 2020-12 schemas by pre-loading the metaschemas for both versions:
 
 >>> catalog = create_catalog('2019-09', '2020-12')
 
@@ -37,6 +37,10 @@ specified when creating new :class:`~jschon.jsonschema.JSONSchema` objects:
 >>> from jschon import JSONSchema
 >>> schema_1 = JSONSchema({"type": "object", ...}, catalog=catalog_1)
 >>> schema_2 = JSONSchema.loadf('/path/to/schema.json', catalog='Catalog 2')
+
+The :class:`~jschon.jsonschema.JSONSchema` constructor automatically uses
+the unnamed default catalog when it calls :method:`~jschon.catalog.Catalog.add_schema`
+unless a different one is provided.
 
 .. _catalog-reference-loading:
 
@@ -61,12 +65,84 @@ Now, the ``"$ref"`` in the following schema resolves to the local file
     }
 
 We can also retrieve :class:`~jschon.jsonschema.JSONSchema` objects by URI
-directly from the catalog:
+directly from the catalog, using the same method that the catalog uses
+to resolve references:
 
 >>> my_schema = catalog.get_schema(URI("https://example.com/schemas/my/schema"))
 
 See :doc:`../examples/file_based_schemas` for further examples of loading
-schemas from disk.
+schemas from disk, and :mod:`jschon.catalog` for documentation on other
+possible sources.
+
+Schema and metaschema caching
+-----------------------------
+Whether a :class:`~jschon.jsonschema.JSONSchema` is instantiated directly or
+through :meth:`~jschon.catalog.Catalog.get_schema`, it is cached within its
+associated :class:`~jschon.catalog.Catalog` instance.
+
+The :class:`~jschon.catalog.Catalog` supports multiple caches, each using
+its own ``cacheid``, which can be provided as a parameter to the
+:class:`~jschon.jsonschema.JSONSchema` constructor and to methods
+such as :meth:`~jschon.jsonschema.Catalog.get_schema`.
+
+>>> from jschon import create_catalog, JSONSchema, URI, CatalogError
+>>> catalog = create_catalog('2020-12')
+>>> schema_data = {
+...     "$schema": "https://json-schema.org/draft/2020-12/schema",
+...     "$id": "https://example.com/foo",
+...     "type": "object"
+... }
+>>> schema_uri = URI(schema_data['$id'])
+>>> schema = JSONSchema(schema_data, cacheid='other')
+>>> cached = catalog.get_schema(URI(schema_data['$id']), cacheid='other')
+>>> cached is schema
+True
+
+Caches are isolated from each other, and references are only resolved within
+the same cache.  However, the same schema data can be instantiated as
+separate objects in different caches:
+
+>>> try:
+...     catalog.get_schema(schema_uri)
+... except CatalogError as e:
+...     print(f'{type(e).__name__}: {e}')
+CatalogError: A source is not available for "https://example.com/foo"
+>>> schema_in_default_cache = JSONSchema(schema_data)
+>>> cached_from_default = catalog.get_schema(schema_uri)
+>>> cached_from_default is schema_in_default_cache
+True
+>>> cached_from_default is cached
+False
+
+:class:`~jschon.vocabulary.Metaschema` instances are automatically cached
+separately from regular :class:`~jschon.jsonschema.JSONSchema` instances.
+This special metaschema cache is used by the
+:meth:`~jschon.jsonschema.JSONSchema.validate` method.  Catalogs constructed
+by the :func:`~jschon.create_metaschema` function have their metaschema cache
+automatically populated by the standard metaschemas for the JSON Schema
+version(s) passed to that function.
+
+>>> catalog_2019 = create_catalog('2019-09', name='2019-09 Catalog')
+>>> JSONSchema(
+...     {"$schema": "https://json-schema.org/draft/2019-09/schema"},
+...     catalog=catalog_2019
+... ).validate().valid
+True
+>>> try:
+...     JSONSchema(
+...         {"$schema": "https://json-schema.org/draft/2020-12/schema"},
+...         catalog=catalog_2019
+...     ).validate().valid
+... except CatalogError as e:
+...     print(f'{type(e).__name__}: {e}')
+CatalogError: A source is not available for "https://json-schema.org/draft/2020-12/schema"
+
+Metaschemas can also be added using the
+:meth:`~jschon.catalog.Catalog.create_metaschema` method.
+
+The metaschema cache and the :class:`~jschon.catalog.Source` configurations
+for a :class:`~jschon.catalog.Catalog` are shared across all of the regular
+:class:`~jschon.jsonschema.JSONSchema` caches within that catalog.
 
 Format validation
 -----------------

--- a/docs/tutorial/jsonschema.rst
+++ b/docs/tutorial/jsonschema.rst
@@ -23,6 +23,11 @@ For the examples shown on the remainder of this page, we'll use the following:
 >>> from jschon import create_catalog
 >>> catalog = create_catalog('2020-12')
 
+This creates a :class:`~jschon.catalog.Catalog` that automatically loads the
+the standard draft 2020-12 metaschema.  Since we did not pass a ``name`` parameter,
+this will be our default catalog that will be used automatically wherever a catalog
+is needed, unless we provide a different :class:`~jschon.catalog.Catalog` instance.
+
 Creating a schema
 -----------------
 There are several different ways to instantiate a :class:`~jschon.jsonschema.JSONSchema`:
@@ -144,6 +149,11 @@ Retrieving a schema from the catalog
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Finally, a :class:`~jschon.jsonschema.JSONSchema` object may be instantiated implicitly,
 when retrieving it by URI from the :class:`~jschon.catalog.Catalog`. If the schema is not
-already cached, it is loaded from disk and compiled on the fly. This approach requires
-the catalog to be configured with an appropriate base URI-to-directory mapping. For
-more information, see :ref:`catalog-reference-loading`.
+already cached, it is loaded from disk (or other configured sources) and compiled on the fly.
+
+This approach requires the catalog to be configured with an appropriate base
+URI-to-source mapping. Configuring a catalog in this way allows schema documents that
+reference each other to be created.  Otherwise, the :class:`~jschon.jsonschema.JSONSchema`
+constructor expects all referenced schemas to already be known to the catalog.
+
+For more information, see :ref:`catalog-reference-loading`.


### PR DESCRIPTION
This adds some explanations of a few Catalog-related topics:

* Creating a catalog is how the standard meta-schemas get loaded
* The default-named catalog is used automatically
* More information on configuring sources
* Mutually referencing schemas can only be loaded through the catalog with sources
* Configuring multiple caches
* Which things are catalog-wide vs cache-specific
* Creating metaschemas via the catalog

_Second half of the replacement for #79, which I know was not slated for 0.10.1.  I will also not be bothered if you deem this too different in style or level of detail from the rest of the tutorial and decline it, or ask for major changes._