### PR TITLE
[trivial] Set the default test suite versions in code

### DIFF
--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -29,6 +29,9 @@ def pytest_generate_tests(metafunc):
     test_files = metafunc.config.getoption("testsuite_file")
     test_descriptions = metafunc.config.getoption("testsuite_description")
 
+    if not test_versions:
+        test_versions = ['2019-09', '2020-12']
+
     base_dir = testsuite_dir / 'tests'
     version_dirs = {
         '2019-09': (metaschema_uri_2019_09, base_dir / 'draft2019-09'),

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     pytest-httpserver
     requests
 commands =
-    coverage run -m pytest {posargs} --testsuite-version=2019-09 --testsuite-version=2020-12
+    coverage run -m pytest {posargs}
 commands_post =
     coverage report
     coverage xml


### PR DESCRIPTION
_Another local branch I'd forgotten about_

Running _only_ draft-next tests is currently a pain because tox.ini hardwires the two supported drafts.  This makes it so that the default version selection occurs when no
--testsuite-version argument is passed.  When it is passed, then _only_ the passed version(s) are run.