### PR TITLE
Run draft-next tests on PR submission

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install .[test]
       - name: Run tests
-        run: tox -e py
+        run: tox -e py -- --testsuite-version=2019-09 --testsuite-version=2020-12 --testsuite-version=next
       - name: Upload coverage
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
This only make sense if PR #97 is accepted (and even then it might not be what's wanted, which is why it's a separate PR).

This leaves the general tox.ini default in place, but runs the draft-next tests for PR submissions to incorporate their coverage (e.g. for PR #93).  We could also enable the optional and format tests, I just didn't have a clear use case for that yet.