### PR TITLE
0.10.3 request: Fully unwrap annotation values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,9 @@ Changelog
 
 v0.10.3 (in development)
 ------------------------
+Bug Fixes:
 
+* Non-scalar annotation values are now fully unwrapped from the JSON class
 
 v0.10.2 (2023-04-20)
 --------------------

--- a/jschon/vocabulary/__init__.py
+++ b/jschon/vocabulary/__init__.py
@@ -161,7 +161,7 @@ KeywordClass = Type[Keyword]
 
 class _UnknownKeyword(Keyword):
     def evaluate(self, instance: JSON, result: Result) -> None:
-        result.annotate(self.json.data)
+        result.annotate(self.json.value)
         result.noassert()
 
 

--- a/jschon/vocabulary/annotation.py
+++ b/jschon/vocabulary/annotation.py
@@ -19,7 +19,7 @@ __all__ = [
 class _AnnotationKeyword(Keyword):
 
     def evaluate(self, instance: JSON, result: Result) -> None:
-        result.annotate(self.json.data)
+        result.annotate(self.json.value)
         result.noassert()
 
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -22,7 +22,12 @@ def test_annotate(key, value):
     assert result.children[key, instpath].valid is True
     assert result.children[key, instpath]._assert is False
     try:
-        assert result.children[key, instpath].annotation == value
+        ann = result.children[key, instpath].annotation
+        assert ann == value
+        assert not isinstance(ann, JSON)
+        if isinstance(ann, list):
+            for item in ann:
+                assert not isinstance(item, JSON)
     except KeyError:
         assert value is None
 

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -1,6 +1,29 @@
 import pytest
 
-from jschon import URIError, JSONSchema
+from jschon import URIError, JSONSchema, JSON
+
+
+def test_unknown_keyword_json_unwrapping():
+    value = {
+        'need': 'to',
+        'test': ['nested', 'structures'],
+    }
+    schema_data = {
+        '$schema': f'https://json-schema.org/draft/2020-12/schema',
+        'foo': value,
+    }
+    schema = JSONSchema(schema_data)
+    basic = schema.evaluate(JSON({})).output('basic')
+    actual = basic['annotations'][0]['annotation']
+
+    assert actual == value
+    assert not isinstance(actual, JSON)
+    for v in actual.values():
+        assert not isinstance(v, JSON)
+        if isinstance(v, list):
+            for item in v:
+                assert not isinstance(item, JSON)
+
 
 @pytest.mark.parametrize('draft', ('2019-09', '2020-12', 'next'))
 def test_non_normalized_id_allowed(draft):


### PR DESCRIPTION
Both the annotation vocabulary and the unknown keywords annotation class were using JSON.data for the annotation value.  This is fine for scalar annotations, but not for object or array annotations like the standard "examples", sometimes "default", and any non-scalar unknown keyword annotations, as the array items or object values are jschon.JSON-wrapped.

Annotations should _either_ be fully jschon.JSON-wrapped _or_ not wrapped at all, so use JSON.value to preserve the scalar behavior and bring objects and arrays into alignment.

@marksparkza it would be fantastic to get this into a 0.10.3 sooner rather than later - for now I'm having to point a project's dependency at my local branch to work around this.  Which is fine at this stage but not ongoing.