### PR TITLE
Fine-grained JSON document structure control

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Features:
 * ``JSONPointer`` and ``RelativeJSONPointer`` now have class attributes defining
   the exceptions that they use, which can be overidden in subclasses
 * Cached properties for accessing document and resource root schemas from subschemas
+* JSON.instantiate_{sequence|mapping}() functions allow more
+  fine-grained control of JSON subclass document structure
 
 
 v0.11.0 (2023-06-03)
@@ -45,8 +47,6 @@ Bug Fixes:
 Documentation:
 
 * Spell 'meta-schema' consistently in tutorials and examples
-
-
 v0.10.2 (2023-04-20)
 --------------------
 Experimental:

--- a/jschon/json.py
+++ b/jschon/json.py
@@ -75,7 +75,13 @@ class JSON(MutableSequence['JSON'], MutableMapping[str, 'JSON']):
 
         The `parent`, `key`, `itemclass` and `itemkwargs` parameters should
         typically only be used in the construction of compound :class:`JSON`
-        documents by :class:`JSON` subclasses.
+        documents by :class:`JSON` subclasses.  The use of these parameters
+        can be customized in subclasses by overriding
+        :meth:`instantiate_sequence` and :meth:`instantiate_mapping`, for
+        example if some child elemnts need to be instances of a different
+        class than others.  Child elements instantiated in this way should
+        still be instances of `itemclass` through inheritance, and
+        `itemkwargs` should be respected if at all possible.
 
         :param value: a JSON-compatible Python object
         :param parent: the parent node of the instance
@@ -148,6 +154,11 @@ class JSON(MutableSequence['JSON'], MutableMapping[str, 'JSON']):
         self,
         value: Sequence[JSONCompatible],
     ) -> Sequence[JSON]:
+        """Recursively instantiate JSON arrays.
+
+        By default, instantiate elements as :attr:`itemclass` instances,
+        passing :attr:`itemkwargs` in addition to the parent and key.
+        """
         return [
             self.itemclass(v, parent=self, key=str(i), **self.itemkwargs)
             for i, v in enumerate(value)
@@ -157,6 +168,11 @@ class JSON(MutableSequence['JSON'], MutableMapping[str, 'JSON']):
         self,
         value: Mapping[JSONCompatible],
     ) -> Mapping[JSON]:
+        """Recursively instantiate JSON objects.
+
+        By default, instantiate elements as :attr:`itemclass` instances,
+        passing :attr:`itemkwargs` in addition to the parent and key.
+        """
         return {
             k: self.itemclass(v, parent=self, key=k, **self.itemkwargs)
             for k, v in value.items()

--- a/jschon/json.py
+++ b/jschon/json.py
@@ -135,20 +135,26 @@ class JSON(MutableSequence['JSON'], MutableMapping[str, 'JSON']):
 
         elif isinstance(value, Sequence):
             self.type = "array"
-            self.data = [
-                self.itemclass(v, parent=self, key=str(i), **self.itemkwargs)
-                for i, v in enumerate(value)
-            ]
+            self.data = self.instantiate_sequence(value)
 
         elif isinstance(value, Mapping):
             self.type = "object"
-            self.data = {
-                k: self.itemclass(v, parent=self, key=k, **self.itemkwargs)
-                for k, v in value.items()
-            }
+            self.data = self.instantiate_mapping(value)
 
         else:
             raise TypeError(f"{value=} is not JSON-compatible")
+
+    def instantiate_sequence(self, value):
+        return [
+            self.itemclass(v, parent=self, key=str(i), **self.itemkwargs)
+            for i, v in enumerate(value)
+        ]
+
+    def instantiate_mapping(self, value):
+        return {
+            k: self.itemclass(v, parent=self, key=k, **self.itemkwargs)
+            for k, v in value.items()
+        }
 
     @cached_property
     def path(self) -> JSONPointer:

--- a/jschon/json.py
+++ b/jschon/json.py
@@ -144,13 +144,19 @@ class JSON(MutableSequence['JSON'], MutableMapping[str, 'JSON']):
         else:
             raise TypeError(f"{value=} is not JSON-compatible")
 
-    def instantiate_sequence(self, value):
+    def instantiate_sequence(
+        self,
+        value: Sequence[JSONCompatible],
+    ) -> Sequence[JSON]:
         return [
             self.itemclass(v, parent=self, key=str(i), **self.itemkwargs)
             for i, v in enumerate(value)
         ]
 
-    def instantiate_mapping(self, value):
+    def instantiate_mapping(
+        self,
+        value: Mapping[JSONCompatible],
+    ) -> Mapping[JSON]:
         return {
             k: self.itemclass(v, parent=self, key=k, **self.itemkwargs)
             for k, v in value.items()


### PR DESCRIPTION
Fixes #99, enabling possibe OpenAPI 3.x support as an extension.

This factors the instantiation of list items and object values into their own methods to allow more flexible determination of whether a sub-structure is a JSON Schema or not.  This will allow using jschon with formats like OpenAPI that embed schemas in complex pattern of locations, without the root object being a schema.

@marksparkza while I'd love to get this into a 0.10.3, I realize it potentially has more substantial implications by defining an extension interface.  If this approach feels like it needs more work, I would be happy for this to be bumped to a future release if it means #100 can go out in an earlier 0.10.3 release, as that one is a bugfix that will have immediate impact.