### PR TITLE
Allow changing [Relative]JSONPointer exceptions in subclasses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,10 @@ Changelog
 
 v0.11.1 (in development)
 ------------------------
+Features:
+
+* ``JSONPointer`` and ``RelativeJSONPointer`` now have class attributes defining
+  the exceptions that they use, which can be overidden in subclasses
 
 
 v0.11.0 (2023-06-03)

--- a/jschon/jsonpointer.py
+++ b/jschon/jsonpointer.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import collections
 import re
 import urllib.parse
-from typing import Any, Iterable, Literal, Mapping, Sequence, TYPE_CHECKING, Union, overload
+from typing import (
+    Any, Iterable, Literal, Mapping, Sequence, Type, TYPE_CHECKING, Union, overload,
+)
 
 from jschon.exc import (
     JSONPointerMalformedError,
@@ -71,10 +73,10 @@ class JSONPointer(Sequence[str]):
     """
 
     malformed_exc: Type[JSONPointerMalformedError] = JSONPointerMalformedError
-    """The exception to raise if the input is not a valid JSON Pointer"""
+    """Exception raised when the input is not a valid JSON Pointer."""
 
     reference_exc: Type[JSONPointerReferenceError] = JSONPointerReferenceError
-    """The exception to raise if the JSON Pointer cannot be resolved against a document"""
+    """Exception raised when the JSON Pointer cannot be resolved against a document."""
 
     _json_pointer_re = re.compile(JSON_POINTER_RE)
     _array_index_re = re.compile(JSON_INDEX_RE)
@@ -85,7 +87,7 @@ class JSONPointer(Sequence[str]):
 
         :param values: each value may either be an RFC 6901 string, or an iterable
             of unescaped keys
-        :raise cls.malformed_exc: if a string argument does not conform to
+        :raise JSONPointerMalformedError: if a string argument does not conform to
             the RFC 6901 syntax
         """
         self = object.__new__(cls)
@@ -190,7 +192,7 @@ class JSONPointer(Sequence[str]):
         will always fail.
 
         :param document: any Python object
-        :raise self.reference_exc: if `self` references a non-existent
+        :raise JSONPointerReferenceError: if `self` references a non-existent
             location in `document`
         """
 
@@ -275,11 +277,11 @@ class RelativeJSONPointer:
     malformed_exc: Type[
         RelativeJSONPointerMalformedError
     ] = RelativeJSONPointerMalformedError
-    """The exception to raise if the input is not a valid Relative JSON Pointer"""
+    """Exception raised when the input is not a valid Relative JSON Pointer."""
     reference_exc: Type[
         RelativeJSONPointerReferenceError
     ] = RelativeJSONPointerReferenceError
-    """The exception to raise if the Relative JSON Pointer cannot be resolved against a document"""
+    """Exception raised when the Relative JSON Pointer cannot be resolved against a document."""
 
     _regex = re.compile(RELATIVE_JSON_POINTER_RE)
 
@@ -303,7 +305,7 @@ class RelativeJSONPointer:
             a value of 0, which is not allowed by the grammar, is treated as if
             there is no adjustment.
         :param ref: a :class:`JSONPointer` instance, or the literal ``'#'``
-        :raise cls.malformed_exc: for any invalid arguments
+        :raise RelativeJSONPointerMalformedError: for any invalid arguments
         """
         self = object.__new__(cls)
 
@@ -360,7 +362,7 @@ class RelativeJSONPointer:
         on parent and sibling links provided by that class.
 
         :param document: a :class:`JSON` instance representing the document
-        :raise self.reference_exc: if `self` references a non-existent
+        :raise RelativeJSONPointerReferenceError: if `self` references a non-existent
             location in `document`
         """
         node = document

--- a/tests/test_jsonpointer.py
+++ b/tests/test_jsonpointer.py
@@ -4,7 +4,7 @@ from copy import copy
 from typing import Dict, List, Union
 
 import pytest
-from hypothesis import given, strategies as hs
+from hypothesis import example, given, strategies as hs
 
 from jschon import JSON, JSONCompatible, JSONPointer, RelativeJSONPointer
 from jschon.exc import (
@@ -127,6 +127,7 @@ def test_uri_fragment_safe_characters():
 
 @pytest.mark.parametrize('jp_cls', (JSONPointer, JPtr))
 @given(json, jsonpointer_key)
+@example('~', '')
 def test_evaluate_jsonpointer(jp_cls, value, testkey):
     assert jp_cls().evaluate(value) == value
     assert jp_cls().evaluate(JSON(value)) == value
@@ -153,7 +154,7 @@ def test_evaluate_jsonpointer(jp_cls, value, testkey):
             assert exc_info.type == jp_cls.reference_exc
     else:
         with pytest.raises(jp_cls.reference_exc) as exc_info:
-            jp_cls(f'/{value}').evaluate(value)
+            jp_cls('/foo').evaluate(value)
         assert exc_info.type == jp_cls.reference_exc
 
 

--- a/tests/test_jsonpointer.py
+++ b/tests/test_jsonpointer.py
@@ -139,13 +139,13 @@ def test_evaluate_jsonpointer(jp_cls, value, testkey):
     if isinstance(value, list):
         with pytest.raises(jp_cls.reference_exc) as exc_info:
             jp_cls(f'/{len(value)}').evaluate(value)
-            assert exc_info.type == jp_cls.reference_exc
+        assert exc_info.type == jp_cls.reference_exc
         with pytest.raises(jp_cls.reference_exc) as exc_info:
             jp_cls('/-').evaluate(value)
-            assert exc_info.type == jp_cls.reference_exc
+        assert exc_info.type == jp_cls.reference_exc
         with pytest.raises(jp_cls.reference_exc) as exc_info:
             jp_cls('/').evaluate(value)
-            assert exc_info.type == jp_cls.reference_exc
+        assert exc_info.type == jp_cls.reference_exc
     elif isinstance(value, dict):
         if testkey not in value:
             with pytest.raises(jp_cls.reference_exc) as exc_info:


### PR DESCRIPTION
Fixes #103.

This add class attributes to JSONPointer and RelativeJSONPointer allowing subclasses to change the exception classes used for malformed input and resolution errors.

I was not able to figure out how to get Sphinx to capture the docstrings on the class attributes.  Everything I attempted either provoked errors or put the resulting docs in the wrong place (usually both).  Even when I could get one class's docstrings showing up in the right place, Sphinx got confused about the two classes having class attributes with the same names, and wouldn't stop showing the default about the attributes being aliases for the existing exception classes.  After spending a few hours banging my head against the Sphinx documentation, I gave up - any suggestions would be welcome.