### PR TITLE
Instantiate correct [R]JP subclasses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,11 @@ v0.11.1 (in development)
 Features:
 
 * Allow adding a source with a base URI of ``None`` to match full URIs as the ``relative_path``
-* ``JSONPointer`` and ``RelativeJSONPointer`` now have class attributes defining
-  the exceptions that they use, which can be overidden in subclasses
+* ``JSONPointer``, ``RelativeJSONPointer`` and their related exceptions can
+  now be subclassed together; the base classes will instantiate subclasses
+  where appropriate, and class attributes can be set to ensure that subclasses
+  will use subclassed exceptions, and a subclassed ``RelativeJSONPointer`` will
+  use its companion subclass of ``JSONPointer``
 * Cached properties for accessing document and resource root schemas from subschemas
 
 

--- a/tests/test_jsonpointer.py
+++ b/tests/test_jsonpointer.py
@@ -1,7 +1,7 @@
 import pathlib
 import re
 from copy import copy
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Type
 
 import pytest
 from hypothesis import example, given, strategies as hs
@@ -44,6 +44,7 @@ class RJPRefError(RelativeJSONPointerReferenceError):
 class RJPtr(RelativeJSONPointer):
     malformed_exc = RJPMalError
     reference_exc = RJPRefError
+    json_pointer_class = JPtr
 
 
 ##################### End subclasses #########################
@@ -71,19 +72,20 @@ def jsonpointer_unescape(token: str):
     return token.replace('~1', '/').replace('~0', '~')
 
 
+@pytest.mark.parametrize('jp_cls', (JSONPointer, JPtr))
 @given(hs.lists(jsonpointer | hs.lists(jsonpointer_key)))
-def test_create_jsonpointer(values: List[Union[str, List[str]]]):
+def test_create_jsonpointer(jp_cls: Type[JSONPointer], values: List[Union[str, List[str]]]):
     keys = []
     for value in values:
         keys += [jsonpointer_unescape(token) for token in value.split('/')[1:]] if isinstance(value, str) else value
 
-    ptr0 = JSONPointer(*values)
-    assert ptr0 == (ptr1 := JSONPointer(*values))
-    assert ptr0 == (ptr2 := JSONPointer(keys))
-    assert ptr0 == (ptr3 := JSONPointer(ptr0))
-    assert ptr0 != (ptr4 := JSONPointer() if keys else JSONPointer('/'))
-    assert ptr0 != (ptr5 := JSONPointer('/', keys))
-    assert JSONPointer(ptr0, keys, *values) == JSONPointer(*values, keys, ptr0)
+    ptr0 = jp_cls(*values)
+    assert ptr0 == (ptr1 := jp_cls(*values))
+    assert ptr0 == (ptr2 := jp_cls(keys))
+    assert ptr0 == (ptr3 := jp_cls(ptr0))
+    assert ptr0 != (ptr4 := jp_cls() if keys else jp_cls('/'))
+    assert ptr0 != (ptr5 := jp_cls('/', keys))
+    assert jp_cls(ptr0, keys, *values) == jp_cls(*values, keys, ptr0)
 
     ptrs = {ptr0, ptr1, ptr2, ptr3}
     assert ptrs == {ptr0}
@@ -103,17 +105,21 @@ def test_malformed_jsonpointer(jp_cls):
     assert exc_info.type == jp_cls.malformed_exc
 
 
+@pytest.mark.parametrize('jp_cls', (JSONPointer, JPtr))
 @given(jsonpointer, jsonpointer_key)
-def test_extend_jsonpointer_one_key(value, newkey):
-    pointer = JSONPointer(value) / newkey
+def test_extend_jsonpointer_one_key(jp_cls, value, newkey):
+    pointer = jp_cls(value) / newkey
     newtoken = jsonpointer_escape(newkey)
+    assert type(pointer) == jp_cls
     assert pointer[-1] == newkey
     assert str(pointer) == f'{value}/{newtoken}'
 
 
+@pytest.mark.parametrize('jp_cls', (JSONPointer, JPtr))
 @given(jsonpointer, hs.lists(jsonpointer_key))
-def test_extend_jsonpointer_multi_keys(value, newkeys):
-    pointer = (base_ptr := JSONPointer(value)) / newkeys
+def test_extend_jsonpointer_multi_keys(jp_cls, value, newkeys):
+    pointer = (base_ptr := jp_cls(value)) / newkeys
+    assert type(pointer) == jp_cls
     for i in range(len(newkeys)):
         assert pointer[len(base_ptr) + i] == newkeys[i]
     assert str(pointer) == value + ''.join(f'/{jsonpointer_escape(key)}' for key in newkeys)
@@ -160,7 +166,7 @@ def test_evaluate_jsonpointer(jp_cls, value, testkey):
 
 @given(jsonpointer, jsonpointer)
 def test_compare_jsonpointer(value1, value2):
-    ptr1 = JSONPointer(value1)
+    ptr1 = JPtr(value1)
     ptr2 = JSONPointer(value2)
     assert ptr1 == JSONPointer(ptr1)
     assert ptr1 <= JSONPointer(ptr1)
@@ -179,8 +185,9 @@ def test_compare_jsonpointer(value1, value2):
     assert (ptr1 > ptr2) == (ptr1 >= ptr2 and ptr1 != ptr2)
 
 
+@pytest.mark.parametrize('rjp_cls', (RelativeJSONPointer, RJPtr))
 @given(relative_jsonpointer)
-def test_create_relative_jsonpointer(value):
+def test_create_relative_jsonpointer(rjp_cls, value):
     match = re.fullmatch(relative_jsonpointer_regex, value)
     up, over, ref = match.group('up', 'over', 'ref')
     kwargs = dict(
@@ -189,11 +196,14 @@ def test_create_relative_jsonpointer(value):
         ref=JSONPointer(ref) if ref != '#' else ref,
     )
 
-    r1 = RelativeJSONPointer(value)
-    r2 = RelativeJSONPointer(**kwargs)
+    r1 = rjp_cls(value)
+    r2 = rjp_cls(**kwargs)
     assert r1 == r2
     assert str(r1) == value
     assert eval(repr(r1)) == r1
+    if type(kwargs['ref']) == JSONPointer:
+        assert type(r1.path) == rjp_cls.json_pointer_class
+        assert type(r2.path) == rjp_cls.json_pointer_class
 
     oldkwargs = copy(kwargs)
     if up == '0':


### PR DESCRIPTION
Fixes #103 (the rest of it).

Always return an instance of the subclass where appropriate. For RelativeJSONPointer, add a class property for the matching JSONPointer subclass.