### PR TITLE
Add convenience options for test suite config

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -40,10 +40,13 @@ of the test suite, jschon provides the following pytest command line options::
 
   --testsuite-version={2019-09,2020-12,next}
                         JSON Schema version to test. The option may be repeated
-                        to test multiple versions. (default: {2019-09,2020-12})
+                        to test multiple versions, or the value 'all' can be used
+                        to run all versions. (default: {2019-09,2020-12})
   --testsuite-optionals
                         Include optional tests.
   --testsuite-formats   Include format tests.
+  --testsuite-all       Include all possible JSON Schema test suite cases
+                        (all versions, optionals, and formats).
   --testsuite-file=TESTSUITE_FILE
                         Run only this file from the JSON Schema Test Suite.
                         Given as a path relative to the version directory in the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,9 +17,9 @@ def pytest_addoption(parser):
     testsuite.addoption(
         "--testsuite-version",
         action="append",
-        choices=["2019-09", "2020-12", "next"],
-        help="JSON Schema version to test. The option may be repeated to test multiple versions. "
-             "(default: {2019-09,2020-12})",
+        choices=["2019-09", "2020-12", "next", "all"],
+        help="JSON Schema version to test. The option may be repeated to test multiple versions, "
+             "or the value 'all' can be used to run all versions. (default: {2019-09,2020-12})",
     )
     testsuite.addoption(
         "--testsuite-optionals",
@@ -30,6 +30,11 @@ def pytest_addoption(parser):
         "--testsuite-formats",
         action="store_true",
         help="Include format tests.",
+    )
+    testsuite.addoption(
+        "--testsuite-all",
+        action="store_true",
+        help="Include all possible JSON Schema test suite cases (all versions, optionals, and formats).",
     )
     testsuite.addoption(
         "--testsuite-file",

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -8,6 +8,8 @@ from jschon import JSON, JSONSchema, LocalSource, URI
 from jschon.utils import json_loadf
 from tests import metaschema_uri_2019_09, metaschema_uri_2020_12, metaschema_uri_next
 
+ALL_VERSIONS = ('2019-09', '2020-12', 'next')
+
 testsuite_dir = pathlib.Path(__file__).parent / 'JSON-Schema-Test-Suite'
 
 
@@ -95,9 +97,10 @@ def pytest_generate_tests(metafunc):
     testids = []
 
     gen_status_data = metafunc.config.getoption("testsuite_generate_status")
+    run_all = metafunc.config.getoption("testsuite_all")
     status_data = SuiteStatus.get_instance(metafunc, gen_status_data)
-    if gen_status_data:
-        test_versions = ('2019-09', '2020-12', 'next')
+    if gen_status_data or run_all:
+        test_versions = ALL_VERSIONS
         include_optionals = True
         include_formats = True
         test_files = []
@@ -111,6 +114,8 @@ def pytest_generate_tests(metafunc):
 
     if not test_versions:
         test_versions = ['2019-09', '2020-12']
+    elif test_versions == ['all']:
+        test_versions = ALL_VERSIONS
 
     base_dir = testsuite_dir / 'tests'
     version_dirs = {


### PR DESCRIPTION
This adds --testsuite-version=all as a shorthand for specifying all three (currenlty) versions individually, and adds --testsuite-all as a shorthand for passing that plus --testsuite-optionals and --testsuite-formats.  Otherwise, it was getting pretty tiresome to run everything.