### PR TITLE
Add JSON.document_root; test JSON and JSONSchema

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Features:
 * Allow adding a source with a base URI of ``None`` to match full URIs as the ``relative_path``
 * ``JSONPointer`` and ``RelativeJSONPointer`` now have class attributes defining
   the exceptions that they use, which can be overidden in subclasses
+* Cached property for accessing document root node from within JSON documents
 * Cached properties for accessing document and resource root schemas from subschemas
 
 

--- a/jschon/json.py
+++ b/jschon/json.py
@@ -169,6 +169,10 @@ class JSON(MutableSequence['JSON'], MutableMapping[str, 'JSON']):
             return {key: item.value for key, item in self.data.items()}
         return self.data
 
+    @cached_property
+    def document_root(self) -> JSON:
+        return self if self.parent is None else self.parent.document_root
+
     def _invalidate_path(self) -> None:
         try:
             del self.path

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -472,3 +472,16 @@ def test_json_literals():
         "bar": True,
         "baz": False
     })
+
+
+def test_document_root():
+    root = JSON({
+        'a': [42, True, None],
+        'b': 'c',
+    })
+    assert root.document_root is root
+    assert root['a'].document_root is root
+    assert root['a'][0].document_root is root
+    assert root['a'][1].document_root is root
+    assert root['a'][2].document_root is root
+    assert root['b'].document_root is root

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -70,6 +70,16 @@ def weird_parent_schema(catalog):
     )
 
 
+def test_document_root(weird_parent_schema):
+    wps = weird_parent_schema
+    assert wps['foo'].document_root is wps
+    assert wps['foo']['$defs']['a'].document_root is wps
+    assert wps['foo']['$defs']['a']['$defs']['b'] \
+        .document_root is wps
+    assert wps['foo']['$defs']['a']['$defs']['b']['properties']['c'] \
+        .document_root is wps
+
+
 def test_document_rootschema(weird_parent_schema):
     wps = weird_parent_schema
     assert wps['foo'].document_rootschema is wps['foo']


### PR DESCRIPTION
Implements part of https://github.com/marksparkza/jschon/discussions/108#discussioncomment-6471856 This adds a generic document_root cached property to the JSON class, which can be distinct from both the document_schemaroot and resource_schemaroot of the JSONSchema class.

This lays groundwork to support mixed content such as OpenAPI.