### PR TITLE
Temporary solution: Add factory method for URI instantiation

### DIFF
--- a/examples/custom_keyword.py
+++ b/examples/custom_keyword.py
@@ -54,13 +54,13 @@ catalog = create_catalog('2020-12')
 # add a local source for loading the enumRef meta-schema and vocabulary
 # definition files
 catalog.add_uri_source(
-    URI("https://example.com/enumRef/"),
+    URI.get("https://example.com/enumRef/"),
     LocalSource(data_dir, suffix='.json'),
 )
 
 # implement the enumRef vocabulary using the EnumRefKeyword class
 catalog.create_vocabulary(
-    URI("https://example.com/enumRef"),
+    URI.get("https://example.com/enumRef"),
     EnumRefKeyword,
 )
 

--- a/examples/load_from_files_2.py
+++ b/examples/load_from_files_2.py
@@ -4,7 +4,7 @@ from jschon import create_catalog, JSON, JSONSchema, URI, LocalSource
 data_dir = pathlib.Path(__file__).parent / 'data'
 
 catalog = create_catalog('2020-12')
-catalog.add_uri_source(URI('https://example.com/'), LocalSource(data_dir, suffix='.json'))
+catalog.add_uri_source(URI.get('https://example.com/'), LocalSource(data_dir, suffix='.json'))
 
 org_schema = JSONSchema.loadf(data_dir / 'org-schema.json')
 org_data = JSON.loadf(data_dir / 'org-data.json')

--- a/examples/load_from_files_3.py
+++ b/examples/load_from_files_3.py
@@ -4,9 +4,9 @@ from jschon import create_catalog, JSON, URI, LocalSource
 data_dir = pathlib.Path(__file__).parent / 'data'
 
 catalog = create_catalog('2020-12')
-catalog.add_uri_source(URI('https://example.com/'), LocalSource(data_dir, suffix='.json'))
+catalog.add_uri_source(URI.get('https://example.com/'), LocalSource(data_dir, suffix='.json'))
 
-org_schema = catalog.get_schema(URI('https://example.com/org-schema'))
+org_schema = catalog.get_schema(URI.get('https://example.com/org-schema'))
 org_data = JSON.loadf(data_dir / 'org-data.json')
 
 result = org_schema.evaluate(org_data)

--- a/jschon/catalog/_2019_09.py
+++ b/jschon/catalog/_2019_09.py
@@ -12,12 +12,12 @@ from jschon.vocabulary.validation import *
 
 def initialize(catalog: Catalog):
     catalog.add_uri_source(
-        URI('https://json-schema.org/draft/2019-09/'),
+        URI.get('https://json-schema.org/draft/2019-09/'),
         LocalSource(pathlib.Path(__file__).parent / 'json-schema-2019-09', suffix='.json'),
     )
 
     catalog.create_vocabulary(
-        URI("https://json-schema.org/draft/2019-09/vocab/core"),
+        URI.get("https://json-schema.org/draft/2019-09/vocab/core"),
         SchemaKeyword,
         VocabularyKeyword,
         IdKeyword,
@@ -30,7 +30,7 @@ def initialize(catalog: Catalog):
     )
 
     catalog.create_vocabulary(
-        URI("https://json-schema.org/draft/2019-09/vocab/applicator"),
+        URI.get("https://json-schema.org/draft/2019-09/vocab/applicator"),
         AllOfKeyword,
         AnyOfKeyword,
         OneOfKeyword,
@@ -51,7 +51,7 @@ def initialize(catalog: Catalog):
     )
 
     catalog.create_vocabulary(
-        URI("https://json-schema.org/draft/2019-09/vocab/validation"),
+        URI.get("https://json-schema.org/draft/2019-09/vocab/validation"),
         TypeKeyword,
         EnumKeyword,
         ConstKeyword,
@@ -75,12 +75,12 @@ def initialize(catalog: Catalog):
     )
 
     catalog.create_vocabulary(
-        URI("https://json-schema.org/draft/2019-09/vocab/format"),
+        URI.get("https://json-schema.org/draft/2019-09/vocab/format"),
         FormatKeyword,
     )
 
     catalog.create_vocabulary(
-        URI("https://json-schema.org/draft/2019-09/vocab/meta-data"),
+        URI.get("https://json-schema.org/draft/2019-09/vocab/meta-data"),
         TitleKeyword,
         DescriptionKeyword,
         DefaultKeyword,
@@ -91,18 +91,18 @@ def initialize(catalog: Catalog):
     )
 
     catalog.create_vocabulary(
-        URI("https://json-schema.org/draft/2019-09/vocab/content"),
+        URI.get("https://json-schema.org/draft/2019-09/vocab/content"),
         ContentMediaTypeKeyword,
         ContentEncodingKeyword,
         ContentSchemaKeyword,
     )
 
     catalog.create_metaschema(
-        URI("https://json-schema.org/draft/2019-09/schema"),
-        URI("https://json-schema.org/draft/2019-09/vocab/core"),
-        URI("https://json-schema.org/draft/2019-09/vocab/applicator"),
-        URI("https://json-schema.org/draft/2019-09/vocab/validation"),
-        URI("https://json-schema.org/draft/2019-09/vocab/format"),
-        URI("https://json-schema.org/draft/2019-09/vocab/meta-data"),
-        URI("https://json-schema.org/draft/2019-09/vocab/content"),
+        URI.get("https://json-schema.org/draft/2019-09/schema"),
+        URI.get("https://json-schema.org/draft/2019-09/vocab/core"),
+        URI.get("https://json-schema.org/draft/2019-09/vocab/applicator"),
+        URI.get("https://json-schema.org/draft/2019-09/vocab/validation"),
+        URI.get("https://json-schema.org/draft/2019-09/vocab/format"),
+        URI.get("https://json-schema.org/draft/2019-09/vocab/meta-data"),
+        URI.get("https://json-schema.org/draft/2019-09/vocab/content"),
     )

--- a/jschon/catalog/_2020_12.py
+++ b/jschon/catalog/_2020_12.py
@@ -11,12 +11,12 @@ from jschon.vocabulary.validation import *
 
 def initialize(catalog: Catalog):
     catalog.add_uri_source(
-        URI('https://json-schema.org/draft/2020-12/'),
+        URI.get('https://json-schema.org/draft/2020-12/'),
         LocalSource(pathlib.Path(__file__).parent / 'json-schema-2020-12', suffix='.json'),
     )
 
     catalog.create_vocabulary(
-        URI("https://json-schema.org/draft/2020-12/vocab/core"),
+        URI.get("https://json-schema.org/draft/2020-12/vocab/core"),
         SchemaKeyword,
         VocabularyKeyword,
         IdKeyword,
@@ -29,7 +29,7 @@ def initialize(catalog: Catalog):
     )
 
     catalog.create_vocabulary(
-        URI("https://json-schema.org/draft/2020-12/vocab/applicator"),
+        URI.get("https://json-schema.org/draft/2020-12/vocab/applicator"),
         AllOfKeyword,
         AnyOfKeyword,
         OneOfKeyword,
@@ -48,13 +48,13 @@ def initialize(catalog: Catalog):
     )
 
     catalog.create_vocabulary(
-        URI("https://json-schema.org/draft/2020-12/vocab/unevaluated"),
+        URI.get("https://json-schema.org/draft/2020-12/vocab/unevaluated"),
         UnevaluatedItemsKeyword,
         UnevaluatedPropertiesKeyword,
     )
 
     catalog.create_vocabulary(
-        URI("https://json-schema.org/draft/2020-12/vocab/validation"),
+        URI.get("https://json-schema.org/draft/2020-12/vocab/validation"),
         TypeKeyword,
         EnumKeyword,
         ConstKeyword,
@@ -78,12 +78,12 @@ def initialize(catalog: Catalog):
     )
 
     catalog.create_vocabulary(
-        URI("https://json-schema.org/draft/2020-12/vocab/format-annotation"),
+        URI.get("https://json-schema.org/draft/2020-12/vocab/format-annotation"),
         FormatKeyword,
     )
 
     catalog.create_vocabulary(
-        URI("https://json-schema.org/draft/2020-12/vocab/meta-data"),
+        URI.get("https://json-schema.org/draft/2020-12/vocab/meta-data"),
         TitleKeyword,
         DescriptionKeyword,
         DefaultKeyword,
@@ -94,19 +94,19 @@ def initialize(catalog: Catalog):
     )
 
     catalog.create_vocabulary(
-        URI("https://json-schema.org/draft/2020-12/vocab/content"),
+        URI.get("https://json-schema.org/draft/2020-12/vocab/content"),
         ContentMediaTypeKeyword,
         ContentEncodingKeyword,
         ContentSchemaKeyword,
     )
 
     catalog.create_metaschema(
-        URI("https://json-schema.org/draft/2020-12/schema"),
-        URI("https://json-schema.org/draft/2020-12/vocab/core"),
-        URI("https://json-schema.org/draft/2020-12/vocab/applicator"),
-        URI("https://json-schema.org/draft/2020-12/vocab/unevaluated"),
-        URI("https://json-schema.org/draft/2020-12/vocab/validation"),
-        URI("https://json-schema.org/draft/2020-12/vocab/format-annotation"),
-        URI("https://json-schema.org/draft/2020-12/vocab/meta-data"),
-        URI("https://json-schema.org/draft/2020-12/vocab/content"),
+        URI.get("https://json-schema.org/draft/2020-12/schema"),
+        URI.get("https://json-schema.org/draft/2020-12/vocab/core"),
+        URI.get("https://json-schema.org/draft/2020-12/vocab/applicator"),
+        URI.get("https://json-schema.org/draft/2020-12/vocab/unevaluated"),
+        URI.get("https://json-schema.org/draft/2020-12/vocab/validation"),
+        URI.get("https://json-schema.org/draft/2020-12/vocab/format-annotation"),
+        URI.get("https://json-schema.org/draft/2020-12/vocab/meta-data"),
+        URI.get("https://json-schema.org/draft/2020-12/vocab/content"),
     )

--- a/jschon/catalog/__init__.py
+++ b/jschon/catalog/__init__.py
@@ -60,7 +60,7 @@ class RemoteSource(Source):
         self.base_url = base_url
 
     def __call__(self, relative_path: str) -> JSONCompatible:
-        url = str(URI(relative_path).resolve(self.base_url))
+        url = str(URI.get(relative_path).resolve(self.base_url))
         if self.suffix:
             url += self.suffix
 

--- a/jschon/catalog/_next.py
+++ b/jschon/catalog/_next.py
@@ -12,12 +12,12 @@ from jschon.vocabulary.validation import *
 
 def initialize(catalog: Catalog):
     catalog.add_uri_source(
-        URI('https://json-schema.org/draft/next/'),
+        URI.get('https://json-schema.org/draft/next/'),
         LocalSource(pathlib.Path(__file__).parent / 'json-schema-next', suffix='.json'),
     )
 
     catalog.create_vocabulary(
-        URI("https://json-schema.org/draft/next/vocab/core"),
+        URI.get("https://json-schema.org/draft/next/vocab/core"),
         SchemaKeyword,
         VocabularyKeyword,
         IdKeyword_Next,
@@ -30,7 +30,7 @@ def initialize(catalog: Catalog):
     )
 
     catalog.create_vocabulary(
-        URI("https://json-schema.org/draft/next/vocab/applicator"),
+        URI.get("https://json-schema.org/draft/next/vocab/applicator"),
         AllOfKeyword,
         AnyOfKeyword,
         OneOfKeyword,
@@ -49,13 +49,13 @@ def initialize(catalog: Catalog):
     )
 
     catalog.create_vocabulary(
-        URI("https://json-schema.org/draft/next/vocab/unevaluated"),
+        URI.get("https://json-schema.org/draft/next/vocab/unevaluated"),
         UnevaluatedItemsKeyword,
         UnevaluatedPropertiesKeyword,
     )
 
     catalog.create_vocabulary(
-        URI("https://json-schema.org/draft/next/vocab/validation"),
+        URI.get("https://json-schema.org/draft/next/vocab/validation"),
         TypeKeyword,
         EnumKeyword,
         ConstKeyword,
@@ -79,12 +79,12 @@ def initialize(catalog: Catalog):
     )
 
     catalog.create_vocabulary(
-        URI("https://json-schema.org/draft/next/vocab/format-annotation"),
+        URI.get("https://json-schema.org/draft/next/vocab/format-annotation"),
         FormatKeyword,
     )
 
     catalog.create_vocabulary(
-        URI("https://json-schema.org/draft/next/vocab/meta-data"),
+        URI.get("https://json-schema.org/draft/next/vocab/meta-data"),
         TitleKeyword,
         DescriptionKeyword,
         DefaultKeyword,
@@ -95,19 +95,19 @@ def initialize(catalog: Catalog):
     )
 
     catalog.create_vocabulary(
-        URI("https://json-schema.org/draft/next/vocab/content"),
+        URI.get("https://json-schema.org/draft/next/vocab/content"),
         ContentMediaTypeKeyword,
         ContentEncodingKeyword,
         ContentSchemaKeyword,
     )
 
     catalog.create_metaschema(
-        URI("https://json-schema.org/draft/next/schema"),
-        URI("https://json-schema.org/draft/next/vocab/core"),
-        URI("https://json-schema.org/draft/next/vocab/applicator"),
-        URI("https://json-schema.org/draft/next/vocab/unevaluated"),
-        URI("https://json-schema.org/draft/next/vocab/validation"),
-        URI("https://json-schema.org/draft/next/vocab/format-annotation"),
-        URI("https://json-schema.org/draft/next/vocab/meta-data"),
-        URI("https://json-schema.org/draft/next/vocab/content"),
+        URI.get("https://json-schema.org/draft/next/schema"),
+        URI.get("https://json-schema.org/draft/next/vocab/core"),
+        URI.get("https://json-schema.org/draft/next/vocab/applicator"),
+        URI.get("https://json-schema.org/draft/next/vocab/unevaluated"),
+        URI.get("https://json-schema.org/draft/next/vocab/validation"),
+        URI.get("https://json-schema.org/draft/next/vocab/format-annotation"),
+        URI.get("https://json-schema.org/draft/next/vocab/meta-data"),
+        URI.get("https://json-schema.org/draft/next/vocab/content"),
     )

--- a/jschon/jsonschema.py
+++ b/jschon/jsonschema.py
@@ -103,7 +103,7 @@ class JSONSchema(JSON):
             self.data = {}
 
             if self.parent is None and self.uri is None:
-                self.uri = URI(f'urn:uuid:{uuid4()}')
+                self.uri = URI.get(f'urn:uuid:{uuid4()}')
 
             self._bootstrap(value)
 

--- a/jschon/uri.py
+++ b/jschon/uri.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import ClassVar, Optional, Type
+
 import rfc3986
 import rfc3986.exceptions
 import rfc3986.misc
@@ -13,6 +15,29 @@ __all__ = [
 
 
 class URI:
+    _uri_factory: ClassVar[Optional[Type[URI]]] = None
+
+    @classmethod
+    def get(cls, value: str) -> URI:
+        """Instantiate the configured URI subclass.
+
+        See also :meth:`set_uri_factory`.
+        """
+        return cls._uri_factory(value) if cls._uri_factory else URI(value)
+
+    @classmethod
+    def set_uri_factory(cls, factory: Callable[[str], URI]) -> None:
+        """Configure how URIs are modeled.
+
+        **WARNING:** Changing the URI factory after URIs have already
+        been created can lead to unpredictable behavior, including URIs
+        failing to be detected as equal or having the same hash.
+
+        This allows configuring any callable that produces a :class:`URI`
+        subclass, including sublcasses using a different underlying library.
+        """
+        cls._uri_factory = factory
+
     def __init__(self, value: str) -> None:
         self._uriref = rfc3986.uri_reference(value)
 
@@ -20,7 +45,7 @@ class URI:
         return self._uriref.unsplit()
 
     def __repr__(self) -> str:
-        return f"URI({str(self)!r})"
+        return f"{self.__class__.__name__}({str(self)!r})"
 
     def __len__(self) -> int:
         return len(str(self))

--- a/jschon/vocabulary/__init__.py
+++ b/jschon/vocabulary/__init__.py
@@ -69,7 +69,7 @@ class Metaschema(JSONSchema):
                 vocabularies,
             ))
             if len(possible_cores) == 1:
-                self.core_vocabulary = catalog.get_vocabulary(URI(possible_cores[0]))
+                self.core_vocabulary = catalog.get_vocabulary(URI.get(possible_cores[0]))
             else:
                 raise JSONSchemaError(
                     'Cannot determine unique known core vocabulary from '

--- a/jschon/vocabulary/core.py
+++ b/jschon/vocabulary/core.py
@@ -27,7 +27,7 @@ class SchemaKeyword(Keyword):
         super().__init__(parentschema, value)
 
         try:
-            (uri := URI(value)).validate(require_scheme=True, require_normalized=True)
+            (uri := URI.get(value)).validate(require_scheme=True, require_normalized=True)
         except URIError as e:
             raise JSONSchemaError from e
 
@@ -50,7 +50,7 @@ class VocabularyKeyword(Keyword):
 
         for vocab_uri, vocab_required in value.items():
             try:
-                (vocab_uri := URI(vocab_uri)).validate(require_scheme=True, require_normalized=True)
+                (vocab_uri := URI.get(vocab_uri)).validate(require_scheme=True, require_normalized=True)
             except URIError as e:
                 raise JSONSchemaError from e
 
@@ -69,7 +69,7 @@ class IdKeyword(Keyword):
     def __init__(self, parentschema: JSONSchema, value: str):
         super().__init__(parentschema, value)
 
-        (uri := URI(value)).validate(allow_non_empty_fragment=False)
+        (uri := URI.get(value)).validate(allow_non_empty_fragment=False)
         if not uri.is_absolute():
             if (base_uri := parentschema.base_uri) is not None:
                 uri = uri.resolve(base_uri)
@@ -87,7 +87,7 @@ class RefKeyword(Keyword):
         self.refschema = None
 
     def resolve(self) -> None:
-        uri = URI(self.json.data)
+        uri = URI.get(self.json.data)
         if not uri.has_absolute_base():
             if (base_uri := self.parentschema.base_uri) is not None:
                 uri = uri.resolve(base_uri)
@@ -111,7 +111,7 @@ class AnchorKeyword(Keyword):
         super().__init__(parentschema, value)
 
         if (base_uri := parentschema.base_uri) is not None:
-            uri = URI(f'{base_uri}#{value}')
+            uri = URI.get(f'{base_uri}#{value}')
         else:
             raise JSONSchemaError(f'No base URI for "$anchor" value "{value}"')
 
@@ -124,12 +124,12 @@ class DynamicRefKeyword(Keyword):
     def __init__(self, parentschema: JSONSchema, value: str):
         super().__init__(parentschema, value)
 
-        self.fragment = URI(value).fragment
+        self.fragment = URI.get(value).fragment
         self.refschema = None
         self.dynamic = False
 
     def resolve(self) -> None:
-        uri = URI(self.json.data)
+        uri = URI.get(self.json.data)
         if not uri.has_absolute_base():
             if (base_uri := self.parentschema.base_uri) is not None:
                 uri = uri.resolve(base_uri)
@@ -152,7 +152,7 @@ class DynamicRefKeyword(Keyword):
             while target is not None:
                 if (base_uri := target.schema.base_uri) is not None and base_uri not in checked_uris:
                     checked_uris |= {base_uri}
-                    target_uri = URI(f"#{self.fragment}").resolve(base_uri)
+                    target_uri = URI.get(f"#{self.fragment}").resolve(base_uri)
                     try:
                         found_schema = self.parentschema.catalog.get_schema(
                             target_uri, cacheid=self.parentschema.cacheid
@@ -177,7 +177,7 @@ class DynamicAnchorKeyword(Keyword):
         super().__init__(parentschema, value)
 
         if (base_uri := parentschema.base_uri) is not None:
-            uri = URI(f'{base_uri}#{value}')
+            uri = URI.get(f'{base_uri}#{value}')
         else:
             raise JSONSchemaError(f'No base URI for "$dynamicAnchor" value "{value}"')
 

--- a/jschon/vocabulary/future.py
+++ b/jschon/vocabulary/future.py
@@ -17,7 +17,7 @@ class IdKeyword_Next(Keyword):
     def __init__(self, parentschema: JSONSchema, value: str):
         super().__init__(parentschema, value)
 
-        (uri := URI(value)).validate(allow_fragment=False)
+        (uri := URI.get(value)).validate(allow_fragment=False)
         if not uri.is_absolute():
             if (base_uri := parentschema.base_uri) is not None:
                 uri = uri.resolve(base_uri)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,12 +1,12 @@
 from jschon import URI
 
-metaschema_uri_2019_09 = URI("https://json-schema.org/draft/2019-09/schema")
-metaschema_uri_2020_12 = URI("https://json-schema.org/draft/2020-12/schema")
-metaschema_uri_next = URI("https://json-schema.org/draft/next/schema")
+metaschema_uri_2019_09 = URI.get("https://json-schema.org/draft/2019-09/schema")
+metaschema_uri_2020_12 = URI.get("https://json-schema.org/draft/2020-12/schema")
+metaschema_uri_next = URI.get("https://json-schema.org/draft/next/schema")
 
-core_vocab_uri_2019_09 = URI("https://json-schema.org/draft/2019-09/vocab/core")
-core_vocab_uri_2020_12 = URI("https://json-schema.org/draft/2020-12/vocab/core")
-core_vocab_uri_next = URI("https://json-schema.org/draft/next/vocab/core")
+core_vocab_uri_2019_09 = URI.get("https://json-schema.org/draft/2019-09/vocab/core")
+core_vocab_uri_2020_12 = URI.get("https://json-schema.org/draft/2020-12/vocab/core")
+core_vocab_uri_next = URI.get("https://json-schema.org/draft/next/vocab/core")
 
 example_schema = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/tests/test_metaschema.py
+++ b/tests/test_metaschema.py
@@ -28,14 +28,14 @@ def test_metaschema_no_core(vocab_data):
     if vocab_data:
         metaschema_data['$vocabulary'] = vocab_data
         for vocab in vocab_data:
-            catalog.create_vocabulary(URI(vocab))
+            catalog.create_vocabulary(URI.get(vocab))
 
     with pytest.raises(JSONSchemaError):
-        Metaschema(catalog, metaschema_data, uri=URI(metaschema_id))
+        Metaschema(catalog, metaschema_data, uri=URI.get(metaschema_id))
 
 def test_detect_core(catalog):
     metaschema_id = 'https://example.com/meta'
-    metaschema_uri = URI(metaschema_id)
+    metaschema_uri = URI.get(metaschema_id)
     metaschema_data = {
         '$schema': str(metaschema_uri_2020_12),
         '$id': metaschema_id,
@@ -53,7 +53,7 @@ def test_detect_core(catalog):
 
 def test_default_core(catalog):
     metaschema_id = 'https://example.com/meta'
-    metaschema_uri = URI(metaschema_id)
+    metaschema_uri = URI.get(metaschema_id)
     metaschema_data = {
         '$schema': str(metaschema_uri_2020_12),
         '$id': metaschema_id,

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -433,7 +433,7 @@ def test_hierarchical_output(input, valid, catalog):
     output = schema.evaluate(JSON(input)).output('hierarchical')
     assert output['valid'] is valid
 
-    output_schema = catalog.get_schema(URI('https://json-schema.org/draft/next/output/schema'))
+    output_schema = catalog.get_schema(URI.get('https://json-schema.org/draft/next/output/schema'))
     output_validity = output_schema.evaluate(JSON(output))
     assert output_validity.valid is True
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -216,7 +216,7 @@ id_example = {
 def test_base_uri(ptr: str, base_uri: str):
     rootschema = JSONSchema(id_example, metaschema_uri=metaschema_uri_2020_12)
     schema: JSONSchema = JSONPointer.parse_uri_fragment(ptr[1:]).evaluate(rootschema)
-    assert schema.base_uri == URI(base_uri)
+    assert schema.base_uri == URI.get(base_uri)
 
 
 @pytest.mark.parametrize('ptr, uri, canonical', [
@@ -239,7 +239,7 @@ def test_base_uri(ptr: str, base_uri: str):
 def test_uri(ptr: str, uri: str, canonical: bool, catalog):
     rootschema = JSONSchema(id_example, metaschema_uri=metaschema_uri_2020_12)
     schema: JSONSchema = JSONPointer.parse_uri_fragment(ptr[1:]).evaluate(rootschema)
-    assert schema == catalog.get_schema(uri := URI(uri))
+    assert schema == catalog.get_schema(uri := URI.get(uri))
     if canonical:
         # 'canonical' is as per the JSON Schema spec; however, we skip testing of
         # anchored URIs since we have only one way to calculate a schema's canonical URI

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -84,7 +84,7 @@ def status_data():
 @pytest.fixture(autouse=True)
 def setup_remotes(catalog):
     catalog.add_uri_source(
-        URI('http://localhost:1234/'),
+        URI.get('http://localhost:1234/'),
         LocalSource(testsuite_dir / 'remotes'),
     )
 

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -8,7 +8,7 @@ from jschon import URI
 
 @given(hp.urls())
 def test_create_uri(value):
-    uri = URI(value)
+    uri = URI.get(value)
     assert urllib.parse.unquote(str(uri)) == urllib.parse.unquote(value)
     assert eval(repr(uri)) == uri
 
@@ -17,7 +17,8 @@ example = 'http://example.com/foo?bar#baz'
 
 
 def test_uri_parts():
-    uri = URI(example)
+    uri = URI.get(example)
+    assert type(uri) is URI
     assert uri.scheme == 'http'
     assert uri.authority == 'example.com'
     assert uri.path == '/foo'
@@ -38,4 +39,20 @@ def test_uri_parts():
     (dict(authority='elpmaxe.com', path='', query=''), 'http://elpmaxe.com?#baz'),
 ])
 def test_copy_uri(kwargs, result):
-    assert URI(example).copy(**kwargs) == URI(result)
+    assert URI.get(example).copy(**kwargs) == URI.get(result)
+
+
+def test_uri_factory():
+    class URI2(URI):
+        pass
+
+    try:
+        URI.set_uri_factory(URI2)
+        uri2 = URI.get(example)
+        assert type(uri2) is URI2
+    finally:
+        # Test setting to None and also ensure that later tests in this module
+        # get the original URI class and behavior
+        URI.set_uri_factory(None)
+        original_uri = URI.get(example)
+        assert type(original_uri) is URI


### PR DESCRIPTION
_Note: My vague attempts at benchmarking were not able to distinguish the performance impact of this change from noise.  It was quick enough to implement that I figured this was worth posting, and I'm happy to try some performance measurement suggestions.  Or abandon the idea over performance concerns with or without measuring._

In lieu of solving the broader Python ecosystem URI problems, allow substituting an arbitrary callable to produce URI instances.

As this is both an advanced feature an not intended to be a permanent solution, the setting is global and requires careful use.